### PR TITLE
Add missing variables declaration separator

### DIFF
--- a/test/tests/functional/mongos_tests.js
+++ b/test/tests/functional/mongos_tests.js
@@ -44,7 +44,7 @@ exports['Should correctly execute command using mongos'] = {
 
   test: function(configuration, test) {
     var Mongos = configuration.require.Mongos
-      ReadPreference = configuration.require.ReadPreference;
+      , ReadPreference = configuration.require.ReadPreference;
 
     // Attempt to connect
     var server = new Mongos([{


### PR DESCRIPTION
Add missing variables declaration separator to prevent `ReadPreference` to become a global variable.
