### PR TITLE
Correct _server variable name for connect callback

### DIFF
--- a/docs/content/tutorials/cursor.md
+++ b/docs/content/tutorials/cursor.md
@@ -59,7 +59,7 @@ var server = new Server({
 });
 
 // Wait for the connection event
-server.on('connect', function(server) {
+server.on('connect', function(_server) {
   // Execute find
   var cursor = _server.cursor('db.test', {
       find: f("%s.inserts_extend_cursors", configuration.db)


### PR DESCRIPTION
Just a simple rename of the _server variable name in the connect callback function.
