### PR TITLE
Fall back to errmsg when creating MongoError for command errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -28,7 +28,7 @@ MongoError.create = function(options) {
   } else if(typeof options == 'string') {
     err = new MongoError(options);
   } else {
-    err = new MongoError(options.message || "n/a");
+    err = new MongoError(options.message || options.errmsg || "n/a");
     // Other options
     for(var name in options) {
       err[name] = options[name];

--- a/test/runner.js
+++ b/test/runner.js
@@ -163,6 +163,7 @@ var testFiles =[
   , '/test/tests/functional/rs_topology_state_tests.js'
   , '/test/tests/functional/operation_example_tests.js'
   , '/test/tests/functional/cursor_tests.js'
+  , '/test/tests/functional/error_tests.js'
 ]
 
 // Add all the tests to run

--- a/test/tests/functional/error_tests.js
+++ b/test/tests/functional/error_tests.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var f = require('util').format;
+
+exports['should return helpful error when geoHaystack fails'] = {
+  metadata: {
+    requires: {
+      topology: 'single'
+    }
+  },
+
+  test: function(configuration, test) {
+    configuration.newTopology(function(err, server) {
+      var ns = f('%s.geohaystack1', configuration.db);
+      server.on('connect', function(_server) {
+        _server.command('system.$cmd', {geoNear: ns}, {}, function(err, result) {
+          test.ok(/can\'t find ns/.test(err));
+          test.done();
+        });
+      });
+
+      // Start connection
+      server.connect();
+    });
+  }
+};


### PR DESCRIPTION
Hi Christian,

When commands like geoHaystack fail against 2.6, you get back really unhelpful "MongoError: n/a" errors, when errmsg contains much more useful info. Not sure if this is something you did intentionally, but it'll knock out at least one of the handful of remaining issues for [upgrading mongoose to driver 2.x](https://github.com/LearnBoost/mongoose/compare/driver-upgrade)
