### PR TITLE
NODE-351: Don't treat findOne() as a command cursor

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -165,8 +165,12 @@ var execInitialQuery = function(self, query, cmd, options, cursorState, connecti
   var queryCallback = function(err, result) {
     if(err) return callback(err);
 
+    if (result.queryFailure) {
+      return callback(MongoError.create(result.documents[0]), null);
+    }
+
     // Check if we have a command cursor
-    if(Array.isArray(result.documents) && result.documents.length == 1) {
+    if(Array.isArray(result.documents) && result.documents.length == 1 && !cmd.find) {
       if(result.documents[0]['$err'] 
         || result.documents[0]['errmsg']) {
         return callback(MongoError.create(result.documents[0]), null);          
@@ -188,12 +192,6 @@ var execInitialQuery = function(self, query, cmd, options, cursorState, connecti
 
           // Return after processing command cursor
           return callback(null, null);
-      }
-
-      if(Array.isArray(result.documents[0].result)) {
-        cursorState.documents = result.documents[0].result;
-        cursorState.cursorId = Long.ZERO;
-        return callback(null, null);
       }
     }
 


### PR DESCRIPTION
`findOne()` has some absurd behavior right now: it'll error out if the document returned has an 'errmsg' field, it'll only return only `{x:1}` of `{results:[{x:1}]}`. This is because core is treating it as a command cursor. I'm pretty sure you'll also get this behavior if you use `find()` and it happens to only return one doc. I'm not 100% sure this change is correct, but it passes tests (both core and driver) and fixes the issue.

Also, I don't see any cases where the code in L193-196 actually executes, except for the degenerate case where the user happened to insert a document with a `result` key, so I just got rid of it.