### PR TITLE
Prevent closing tailable cursor when initial query returns zero documents

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -523,7 +523,7 @@ Cursor.prototype.next = function(callback) {
     // query, cmd, options, cursorState, callback
     execInitialQuery(self, self.query, self.cmd, self.options, self.cursorState, self.connection, self.logger, self.callbacks, function(err, r) {
       if(err) return handleCallback(callback, err, null);
-      if(self.cursorState.documents.length == 0) {
+      if(self.cursorState.documents.length == 0 && !self.options.tailable && !self.options.awaitData) {
         return setCursorNotified(self, callback);
       }
 


### PR DESCRIPTION
```javascript
var options = {
	tailable: true,
	awaitData: true
};
var cursor = push.find({processed: false}, options);
```

When there is no document matching the given filter, cursor is closed immediately and doesn't listen for new documents. By this little change I was able to achieve a correct behavior - cursor is waiting for new documents.

Although I spent a lot of time exploring how driver works, I'm not 100% sure this is a correct fix. It passes all the tests and our applications are working properly.