### PR TITLE
ISSUE: NODE-417 Resolution. Improving behavior of thrown errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -10,7 +10,7 @@
 function MongoError(message) {
   this.name = 'MongoError';
   this.message = message;
-  this.stack = (new Error()).stack;
+  Error.captureStackTrace(this, MongoError);
 }
 
 /**


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-417

From that issue, this makes it so that the errors generated with `MongoError` now behave in a more logical manner when they are thrown in normal flow or asserted in tests. Previously due to the stack mechanics the message would often be lost making debugging much more challenging.