### PR TITLE
Updated default value of param options.rejectUnauthorized to match documentation

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -33,7 +33,7 @@ var debugFields = ['host', 'port', 'size', 'keepAlive', 'keepAliveInitialDelay',
  * @param {Buffer} [options.cert] SSL Certificate binary buffer
  * @param {Buffer} [options.key] SSL Key file binary buffer
  * @param {string} [options.passphrase] SSL Certificate pass phrase
- * @param {boolean} [options.rejectUnauthorized=true] Reject unauthorized server certificates
+ * @param {boolean} [options.rejectUnauthorized=false] Reject unauthorized server certificates
  * @param {boolean} [options.promoteLongs=true] Convert Long values from the db into Numbers if they fit into 53 bits
  * @fires Connection#connect
  * @fires Connection#close
@@ -87,7 +87,7 @@ var Connection = function(options) {
   this.key = options.key || null;
   this.passphrase = options.passphrase || null;
   this.ssl = typeof options.ssl == 'boolean' ? options.ssl : false;
-  this.rejectUnauthorized = typeof options.rejectUnauthorized == 'boolean' ? options.rejectUnauthorized : true
+  this.rejectUnauthorized = typeof options.rejectUnauthorized == 'boolean' ? options.rejectUnauthorized : false
 
   // If ssl not enabled
   if(!this.ssl) this.rejectUnauthorized = false;


### PR DESCRIPTION
When connecting to a SSL MongoDB server configured to use a self-signed certificate using the node-mongodb-native node library, the connection fails with MongoError DEPTH_ZERO_SELF_SIGNED_CERT. I discovered the error is linked to mongodb-core. According to http://mongodb.github.io/node-mongodb-native/core/tutorials/connecting/, the default options.rejectUnauthorized value should be false which is mandatory when using self-signed certificates.