### PR TITLE
Bubble up auth errors properly

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -28,7 +28,7 @@ MongoError.create = function(options) {
   } else if(typeof options == 'string') {
     err = new MongoError(options);
   } else {
-    err = new MongoError(options.message || options.errmsg || "n/a");
+    err = new MongoError(options.message || options.errmsg || options.$err || "n/a");
     // Other options
     for(var name in options) {
       err[name] = options[name];


### PR DESCRIPTION
A not-authorized error from a cursor returns a result that looks like this: `[ { '$err': 'not authorized for query on gh2942.users', code: 13 } ]`

That gives us the confusing `MongoError: n/a` error message:

```
MongoError: n/a
    at Function.MongoError.create (/home/val/Workspace/10gen/mongoose/node_modules/mongodb/node_modules/mongodb-core/lib/error.js:31:11)
    at queryCallback (/home/val/Workspace/10gen/mongoose/node_modules/mongodb/node_modules/mongodb-core/lib/cursor.js:171:34)
    at Callbacks.emit (/home/val/Workspace/10gen/mongoose/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:84:3)
    at null.messageHandler (/home/val/Workspace/10gen/mongoose/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:219:23)
    at Socket.<anonymous> (/home/val/Workspace/10gen/mongoose/node_modules/mongodb/node_modules/mongodb-core/lib/connection/connection.js:259:22)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at Socket.Readable.push (_stream_readable.js:126:10)
    at TCP.onread (net.js:538:20)
```

In general, I'd recommend that instead of just saying "n/a" we should just give the `require('util').inspect(options)` output so we give better context in these cases