### PR TITLE
After reconnect, it updates the allowable reconnect retries to the option settings

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -176,6 +176,9 @@ var reconnectServer = function(self, state) {
     //
     // Attempt to connect
     state.pool.once('connect', function() {
+      // Reset retries
+      state.currentReconnectRetry = state.reconnectTries;
+      
       // Remove any non used handlers
       var events = ['error', 'close', 'timeout', 'parseError'];
       events.forEach(function(e) {


### PR DESCRIPTION
Each time the driver attempts to reconnect, the driver ticks down the number of available reconnect tries. When it successfully reconnects that number is left permanently declined. This pull request makes it so that when a successful reconnect occurs, the number is increased back to it's allowed limit.