### PR TITLE
Update scram.js

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -135,6 +135,7 @@ ScramSHA1.prototype.auth = function(server, pool, db, username, password, callba
       // Handle the error
       var handleError = function(err, r) {
         if(err) {
+          numberOfValidConnections = numberOfValidConnections - 1;            
           errorObject = err; return false;
         } else if(r.result['$err']) {
           errorObject = r.result; return false;


### PR DESCRIPTION
Decrement the of valid connections on reception of an error.  This allows finish to fall thru and create a "failed to authenticate using scram" message.  Previously if you logged in with an existing user but a bad password, the db.authenticate callback would not receive an error message and the result would be true.