### PR TITLE
Still allow primary only connection if secondaryOnly is true

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -664,7 +664,8 @@ ReplSet.prototype.isConnected = function(options) {
     && options.readPreference.equals(ReadPreference.primary))
     return this.s.replState.isSecondaryConnected() || this.s.replState.isPrimaryConnected();
 
-  if(this.s.secondaryOnlyConnectionAllowed) return this.s.replState.isSecondaryConnected();
+  if(this.s.secondaryOnlyConnectionAllowed
+    && this.s.replState.isSecondaryConnected()) return true;
   return this.s.replState.isPrimaryConnected();
 }
 


### PR DESCRIPTION
If you pass `connectWithNoPrimary` then `secondaryOnlyConnectionAllowed` is set to true but then this breaks a primary-only connection state. If `secondaryOnlyConnectionAllowed` is true then `isConnected` just returned if there was a secondary connected instead of allowing just a primary to still be connected.