### PR TITLE
apply toString('hex') to each buffer in an array when logging

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -388,8 +388,15 @@ Connection.prototype.destroy = function() {
  * @param {Command} command Command to write out need to implement toBin and toBinUnified
  */
 Connection.prototype.write = function(buffer) {
-  // Debug log
-  if(this.logger.isDebug()) this.logger.debug(f('writing buffer [%s] to %s:%s', buffer.toString('hex'), this.host, this.port));
+  // Debug Log
+  if(this.logger.isDebug()) {
+    if(!Array.isArray(buffer)) {
+      this.logger.debug(f('writing buffer [%s] to %s:%s', buffer.toString('hex'), this.host, this.port));
+    } else {
+      for(var i = 0; i < buffer.length; i++)
+        this.logger.debug(f('writing buffer [%s] to %s:%s', buffer[i].toString('hex'), this.host, this.port));
+    }
+  }
   // Write out the command
   if(!Array.isArray(buffer)) return this.connection.write(buffer, 'binary');
   // Iterate over all buffers and write them in order to the socket


### PR DESCRIPTION
Avoid logging binary data