### PR TITLE
Automattic/mongoose#3493

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -327,7 +327,7 @@ Cursor.prototype._find = function(callback) {
     // Return callback
     callback(null, null);
   }
-  
+
   // If we have a raw query decorate the function
   if(self.options.raw || self.cmd.raw) {
     queryCallback.raw = self.options.raw || self.cmd.raw;
@@ -352,7 +352,7 @@ Cursor.prototype._getmore = function(callback) {
 
   // Set the current batchSize
   var batchSize = this.cursorState.batchSize;
-  if(this.cursorState.limit > 0 
+  if(this.cursorState.limit > 0
     && ((this.cursorState.currentLimit + batchSize) > this.cursorState.limit)) {
     batchSize = this.cursorState.limit - this.cursorState.currentLimit;
   }
@@ -745,6 +745,10 @@ var nextFunction = function(self, callback) {
 
     // Get the document
     var doc = self.cursorState.documents[self.cursorState.cursorIndex++];
+
+    if (doc.$err) {
+      return handleCallback(callback, new MongoError(doc.$err));
+    }
 
     // Transform the doc with passed in transformation method if provided
     if(self.cursorState.transforms && typeof self.cursorState.transforms.doc == 'function') {

--- a/test/tests/functional/cursor_tests.js
+++ b/test/tests/functional/cursor_tests.js
@@ -39,7 +39,7 @@ exports['Should iterate cursor'] = {
               test.equal(null, err);
               test.equal(2, d.a);
               test.equal(0, cursor.bufferedCount());
-              // Destroy the server connection        
+              // Destroy the server connection
               _server.destroy();
               // Finish the test
               test.done();
@@ -94,7 +94,7 @@ exports['Should iterate cursor but readBuffered'] = {
               test.equal(null, err);
               test.equal(null, d);
 
-              // Destroy the server connection        
+              // Destroy the server connection
               _server.destroy();
               // Finish the test
               test.done();
@@ -145,7 +145,7 @@ exports['Should callback exhausted cursor with error'] = {
               cursor.next(function(err, d) {
                 test.ok(err);
                 test.equal(null, d);
-                // Destroy the server connection        
+                // Destroy the server connection
                 _server.destroy();
                 // Finish the test
                 test.done();
@@ -154,6 +154,63 @@ exports['Should callback exhausted cursor with error'] = {
           });
         });
       })
+
+      // Start connection
+      server.connect();
+    });
+  }
+};
+
+exports['Handles overflow sort error when exhausting cursor'] = {
+  metadata: {
+    requires: {
+      topology: "single"
+    }
+  },
+
+  test: function(configuration, test) {
+    configuration.newTopology(function(err, server) {
+      var ns = f("%s.cursor4", configuration.db);
+      // Add event listeners
+      server.on('connect', function(_server) {
+        var totalCount = 1024;
+        var numOutstanding = totalCount;
+        for (var i = 0; i < totalCount; ++i) {
+          var doc = { f: require('crypto').pseudoRandomBytes(32 * totalCount) };
+          _server.insert(ns, doc, { w: 1 }, function(error) {
+            test.equal(error, null);
+            if (!--totalCount) {
+              doQuery();
+            }
+          });
+        }
+
+        var numInCursor = 0;
+        var exhaust = function(cursor, callback) {
+          cursor.next(function(error, res) {
+            if (error) {
+              return callback(error);
+            }
+            if (!res) {
+              return callback(null);
+            }
+            exhaust(cursor, callback);
+          });
+        };
+
+        var doQuery = function() {
+          var sort = { f: 1, _id: 1 }
+          var cursor = _server.cursor(ns,
+            { find: ns, query: {}, batchSize: totalCount, sort: sort });
+          exhaust(cursor, function(error) {
+            test.ok(error);
+            var message = error.toString();
+            test.ok(message.indexOf('Overflow sort stage') !== -1);
+            _server.destroy();
+            test.done();
+          });
+        };
+      });
 
       // Start connection
       server.connect();


### PR DESCRIPTION
Re Automattic/mongoose#3493, the below script fails against mongodb 3.0.5 - it returns the first ~800 docs rather than properly returning an overflow sort stage error.

```javascript
'use strict';

var assert = require('assert');
var crypto = require('crypto');
var mongodb = require('mongodb');

mongodb.MongoClient.connect('mongodb://localhost:27017/gh3493', function(error, db) {
  assert.ifError(error);

  var totalCount = 1024;
  var bulk = db.collection('overflow').initializeUnorderedBulkOp();
  for (var i = 0; i < totalCount; i++) {
    bulk.insert({f: crypto.pseudoRandomBytes(32 * 1024)});
  }
  bulk.execute(function(err, result) {
    assert.ifError(err);

    assert.equal(result.nInserted, totalCount, 'Unexpected number of documents inserted.');
    db.collection('overflow').find({}).sort({f: 1, _id: 1}).toArray(function(err, results) {
      console.log(results.length, totalCount);
      console.log(err);
      if (!err) {
        if (results) {
          // This assert fails
          assert.equal(results.length, totalCount, 'Invalid number of documents returned instead of error.');
        }
        assert.fail('Sort overflow did not throw error.');
      }
      console.log('done');
      process.exit(0);
    });
  });
});
```

This PR makes CoreCursor check for `$err` before saying that 'next' succeeded. Might not be safe for older mongodb versions that support keys that start with '$' but this is the best idea I have right now - I'm open to alternative solutions.