### PR TITLE
Resetting index when capping connection pool

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -217,6 +217,12 @@ Pool.prototype.capConnections = function(maxConnections) {
     var connections = this.connections.slice(maxConnections);
     // Cap the active connections
     this.connections = this.connections.slice(0, maxConnections);
+
+    if (this.index >= maxConnections){
+      // Go back to the beggining of the pool if capping connections
+      this.index = 0;
+    }
+
     // Remove all listeners
     for(var i = 0; i < connections.length; i++) {
       connections[i].removeAllListeners('close');

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -699,7 +699,8 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
   var connection = options.connection || self.s.pool.get();
 
   // Double check if we have a valid connection
-  if(!connection.isConnected()) {
+  // Checking that the connection exists to avoid an uncaught exception in case there is an issue with the pool
+  if(!(connection && connection.isConnected())) {
     return callback(new MongoError(f("no connection available to server %s", self.name)));
   }
 


### PR DESCRIPTION
# Context
After migrating to mongo driver 2.x we got this error (including here for full context):
```
TypeError: Cannot read property 'isConnected' of undefined
    at executeSingleOperation (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:702:17)
    at Server.command (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:830:12)
    at /usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:364:12
    at /usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:353:18
    at ScramSHA1.reauthenticate (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/auth/scram.js:303:25)
    at applyAuthentications (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:349:36)
    at null.<anonymous> (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:361:5)
    at g (events.js:257:16)
    at emitOne (events.js:77:13)
    at emit (events.js:166:7)
    at null.<anonymous> (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/connection/pool.js:125:12)
    at emitOne (events.js:77:13)
    at emit (events.js:166:7)
    at Socket.<anonymous> (/usr/local/lib/node_modules/auth0-api2/node_modules/mongodb/node_modules/mongodb-core/lib/connection/connection.js:365:12)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:163:7)
```

# Issue
Based on the stack trace, the only way to get `undefined` for `connection` in [this line](https://github.com/christkv/mongodb-core/blob/master/lib/topologies/server.js#L699) is if the pool's `index` is pointing to a wrong place in the `connections` array.

After going through the code in `pool.js` the only place where I could find that the `index` invariant is broken is in `capConnections`.

# Fix
To fix the issue I'm resetting the `index` when capping the connections if the current index value is invalid. The reason for choosing 0 is that it maintains the round-robin approach as the next valid connection would have been at index 0.

I also added a check to verify that the `connection` actually exists in case there are any other issues with the `connections` pool, as otherwise an exception would crash apps.

Let me know if you have any feedback.