### PR TITLE
Allow node process to close after db.close() when using ReplSet

### DIFF
--- a/lib/topologies/replset_state.js
+++ b/lib/topologies/replset_state.js
@@ -158,6 +158,9 @@ State.prototype.destroy = function() {
   this.secondaries.forEach(function(s) {
     s.destroy();
   });
+  this.arbiters.forEach(function(s) {
+    s.destroy();
+  });
 }
 
 /**


### PR DESCRIPTION
Currently if you open a connection to a replica set including an arbiter, and you attempt to close it, the process will stay open forever. This is due to two issues, the first is that we don't close arbiter connections, the second is the that the haTimer has to wait to expire. This pull request closes arbiters and unifies the setting of the various haTimers so that on a ReplSet.destroy() we can clear the timer and the process will close immediately. Once merged, when a db.close() is performed everything cascades properly and the process will be able to exit.

I'm testing this on mongodb 2.6 + node 0.12.7, but judging from the code I believe it should occur with all versions of Mongo / Node.

Test case:

```js
var mongodb = require("mongodb");
var async = require("async");

// change to your urls: replica, replica, arbiter
var dbUrl = "mongodb://repl1,repl2,arbiter/admin";
var authUser = "authUser";
var authPassword = "authPassword";

mongodb.MongoClient.connect(dbUrl, { replSet : { replicaSet : "dev_cluster1" } }, function(err, db) {
	if (err) { throw err; }
	
	db.authenticate(authUser, authPassword, { authMechanism : "MONGODB-CR" }, function(err) {
		if (err) { throw err; }
		
		db.close(function(err) {
			if (err) { throw err; }
			
			console.log("process should exit");
		});
	});
})
```