### PR TITLE
fix explain() in 3.0 or lower; find all docs, or up to specified limit()

### DIFF
--- a/lib/wireprotocol/2_4_support.js
+++ b/lib/wireprotocol/2_4_support.js
@@ -189,9 +189,10 @@ var setupClassicFind = function(bson, ns, cmd, cursorState, topology, options) {
   if(cmd.comment) findCmd['$comment'] = cmd.comment, usesSpecialModifier = true;
   if(cmd.maxTimeMS) findCmd['$maxTimeMS'] = cmd.maxTimeMS, usesSpecialModifier = true;
 
-  // If we have explain, return a single document and close cursor
   if(cmd.explain) {
-    numberToReturn = 0;
+	// nToReturn must be 0 (match all) or negative (match N and close cursor)
+	// nToReturn > 0 will give explain results equivalent to limit(0)
+    numberToReturn = -Math.abs(cmd.limit || 0);
     usesSpecialModifier = true;
     findCmd['$explain'] = true;
   }

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -179,9 +179,10 @@ var setupClassicFind = function(bson, ns, cmd, cursorState, topology, options) {
   if(cmd.comment) findCmd['$comment'] = cmd.comment, usesSpecialModifier = true;
   if(cmd.maxTimeMS) findCmd['$maxTimeMS'] = cmd.maxTimeMS, usesSpecialModifier = true;
 
-  // If we have explain, return a single document and close cursor
   if(cmd.explain) {
-    numberToReturn = 0;
+	// nToReturn must be 0 (match all) or negative (match N and close cursor)
+	// nToReturn > 0 will give explain results equivalent to limit(0)
+    numberToReturn = -Math.abs(cmd.limit || 0);
     usesSpecialModifier = true;
     findCmd['$explain'] = true;
   }


### PR DESCRIPTION
Up to 8ad542a5cf3c42c58928dc13175b584a29536aaf, each `explain()` was hard-limited to finding only the first matching document. Currently, however, if the user actually *does* specify a limit using `find().limit(N).explain()`, it will be ignored and **all** documents will be found.

This commit fixes `explain()`so that it finds all documents if no limit is specified, or finds the first N documents if a `limit()` is specified.