### PR TITLE
state is not defined in mongos. 

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -564,7 +564,7 @@ Mongos.prototype.command = function(ns, cmd, options, callback) {
         // Finished executing command
         if(count == 0) {
           // Was it a logout command clear any credentials
-          if(cmd.logout) clearCredentials(state, ns);
+          if(cmd.logout) clearCredentials(self.s, ns);
           // Return the error
           callback(err, r);
         }


### PR DESCRIPTION
I found this error in mongos when logout. I checked code. 'clearCredentials' is called in same way except this. So I changed it into the same way, which it is called otherplace.