### PR TITLE
Allow connection to secondary if primaryPreferred or secondaryPreferred

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -696,8 +696,17 @@ ReplSet.prototype.isConnected = function(options) {
     && options.readPreference.equals(ReadPreference.primary))
     return this.s.replState.isSecondaryConnected() || this.s.replState.isPrimaryConnected();
 
+  if(options.readPreference
+    && options.readPreference.equals(ReadPreference.primaryPreferred))
+    return this.s.replState.isSecondaryConnected() || this.s.replState.isPrimaryConnected();
+
+  if(options.readPreference
+    && options.readPreference.equals(ReadPreference.secondaryPreferred))
+    return this.s.replState.isSecondaryConnected() || this.s.replState.isPrimaryConnected();
+
   if(this.s.secondaryOnlyConnectionAllowed
     && this.s.replState.isSecondaryConnected()) return true;
+    
   return this.s.replState.isPrimaryConnected();
 }
 

--- a/test/tests/functional/rs_mocks/read_preferences_tests.js
+++ b/test/tests/functional/rs_mocks/read_preferences_tests.js
@@ -475,3 +475,157 @@ exports['Should correctly round robin secondary reads'] = {
     server.connect();
   }
 }
+
+exports['Should correctly fall back to a secondary server if the readPreference is primaryPreferred'] = {
+  metadata: {
+    requires: {
+      generators: true,
+      topology: "single"
+    }
+  },
+
+  test: function(configuration, test) {
+    var ReplSet = configuration.require.ReplSet,
+      ObjectId = configuration.require.BSON.ObjectId,
+      ReadPreference = configuration.require.ReadPreference,
+      Long = configuration.require.BSON.Long,
+      MongoError = configuration.require.MongoError,
+      co = require('co'),
+      mockupdb = require('../../../mock');
+
+    // Contain mock server
+    var primaryServer = null;
+    var firstSecondaryServer = null;
+    var running = true;
+    var electionIds = [new ObjectId(), new ObjectId()];
+
+    // Extend the object
+    var extend = function(template, fields) {
+      for(var name in template) fields[name] = template[name];
+      return fields;
+    }
+
+    // Default message fields
+    var defaultFields = {
+      "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
+      "maxBsonObjectSize" : 16777216, "maxMessageSizeBytes" : 48000000,
+      "maxWriteBatchSize" : 1000, "localTime" : new Date(), "maxWireVersion" : 4,
+      "minWireVersion" : 0, "ok" : 1, "hosts": ["localhost:32000", "localhost:32001"]
+    }
+
+    // Primary server states
+    var primary = [extend(defaultFields, {
+      "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
+    })];
+
+    // Primary server states
+    var firstSecondary = [extend(defaultFields, {
+      "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
+    })];
+
+    // Boot the mock
+    co(function*() {
+      primaryServer = yield mockupdb.createServer(32000, 'localhost');
+      firstSecondaryServer = yield mockupdb.createServer(32001, 'localhost');
+
+      // Primary state machine
+      co(function*() {
+        while(running) {
+          var request = yield primaryServer.receive();
+          // Get the document
+          var doc = request.document;
+          if(doc.ismaster) {
+            request.reply(primary[0]);
+          } else if(doc.count) {
+            request.reply({ "waitedMS" : Long.ZERO, "n" : 1, "ok" : 1});
+          }
+        }
+      });
+
+      // First secondary state machine
+      co(function*() {
+        while(running) {
+          var request = yield firstSecondaryServer.receive();
+          var doc = request.document;
+
+          if(doc.ismaster) {
+            request.reply(firstSecondary[0]);
+          } else if(doc.count) {
+            request.reply({ "waitedMS" : Long.ZERO, "n" : 1, "ok" : 1});
+          }
+        }
+      }).catch(function(err) {
+        console.log(err.stack);
+      });
+    });
+
+    // mock ops store from node-mongodb-native for handling repl set disconnects
+    mockDisconnectHandler = {
+        add: function(opType, ns, ops, options, callback) {
+            // Command issued to replSet will fail immediately if !server.isConnected()
+            return callback(MongoError.create({message: "no connection available", driver:true}));
+        },
+        execute: function() {
+            // method needs to be called, so provide a dummy version
+            return;
+        }
+    };
+
+    // Attempt to connect
+    var server = new ReplSet([
+      { host: 'localhost', port: 32000 },
+      { host: 'localhost', port: 32001 }], {
+        setName: 'rs',
+        connectionTimeout: 3000,
+        socketTimeout: 0,
+        haInterval: 2000,
+        disconnectHandler: mockDisconnectHandler,
+        size: 1
+    });
+
+    // Add event listeners
+    server.on('fullsetup', function(_server) {
+      function schedule() {
+        setTimeout(function() {
+          // Perform a find
+          _server.command('test.test', {
+              count: 'test.test'
+            , batchSize: 2
+          }, {
+            readPreference: new ReadPreference('primaryPreferred')
+          }, function(err, r) {
+            test.equal(err, null);
+            test.equal(32000, r.connection.port);
+
+            primaryServer.destroy();
+
+            _server.on('left', function() {
+                // Perform another find, after primary is gone
+                _server.command('test.test', {
+                    count: 'test.test'
+                    , batchSize: 2
+                }, {
+                  readPreference: new ReadPreference('primaryPreferred')
+                }, function(err, r) {
+                  test.equal(err, null);
+                  test.equal(32001, r.connection.port); // reads from secondary while primary down
+
+                  firstSecondaryServer.destroy();
+                  server.destroy();
+                  running = false;
+
+                  test.done();
+                  return;
+                });
+            });
+          });
+        }, 500);
+      }
+
+      // Schedule a commands
+      schedule();
+    });
+
+    server.connect();
+  }
+}


### PR DESCRIPTION
If the read preference is `primaryPreferred` or `secondaryPreferred`, `isConnected()` should return true if either a primary or secondary node are connected.

JIRA ticket: [https://jira.mongodb.org/browse/NODE-628](https://jira.mongodb.org/browse/NODE-628)