### PR TITLE
Initial implementation of a pool implemented using a queue and workers

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -58,6 +58,7 @@ var Pool = function(options) {
   // Contains all connections
   this.connections = [];
   this.available = [];
+  this.monitorAvailable = [];
   this.state = DISCONNECTED;
   this.queryQueue = [];
   // Round robin index
@@ -127,8 +128,13 @@ var connectHandler = function(self) {
   return function(connection) {
     self.connections.push(connection);
     self.available.push(connection);
+    
     // We have connected to all servers
     if(self.connections.length == self.size) {
+      if (self.monitoring === true) {
+        self.monitorAvailable.push(self.connections[self.connections.length - 1]);
+      }
+      
       self.state = CONNECTED;
       // Done connecting
       self.emit("connect", self);
@@ -162,6 +168,7 @@ Pool.prototype.destroy = function(err) {
   
   this.queryQueue = [];
   this.available = [];
+  this.monitorAvailable = [];
 }
 
 var execute = null;
@@ -317,14 +324,19 @@ Pool.prototype._processQueue = function() {
   var self = this;
   
   // check to see if there is queries in queue and available connections to process
-  if (self.queryQueue.length === 0 || self.available.length === 0) { return; }
+  if (self.queryQueue.length === 0) { return; }
+  
+  var possibleQuery = self.queryQueue[0];
+  var connectionPool = possibleQuery.monitoring === true && self.monitoring === true ? self.monitorAvailable : self.available;
+  
+  if (connectionPool.length === 0) { return; }
   
   var queryArgs = self.queryQueue.shift();
-  var connection = self.available.shift();
+  var connection = connectionPool.shift();
   
   var complete = function(err, result) {
     // make our connection available again
-    self.available.push(connection);
+    connectionPool.push(connection);
     
     // pass the returned values to our original callback
     queryArgs.cb.apply(null, arguments);

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -248,27 +248,27 @@ Pool.prototype.get = function(options) {
  * @param {number} maxConnections reduce the poolsize to maxConnections
  */
 Pool.prototype.capConnections = function(maxConnections) {
-    while(this.connections.length > maxConnections) {
-      // removes connections off the front so that our monitor socket (the last socket) is intact
-      var connection = this.connections.shift();
-      connection.removeAllListeners('close');
-      connection.removeAllListeners('error');
-      connection.removeAllListeners('timeout');
-      connection.removeAllListeners('parseError');
-      connection.removeAllListeners('connect');
-      connection.destroy();
-      
-      // if this connection is in the available pool, make sure it's popped off the queue
-      var index = this.available.indexOf(connection);
-      if (index > -1) {
-        this.available.splice(index, 1);
-      }
-    }
+  while(this.connections.length > maxConnections) {
+    // removes connections off the front so that our monitor socket (the last socket) is intact
+    var connection = this.connections.shift();
+    connection.removeAllListeners('close');
+    connection.removeAllListeners('error');
+    connection.removeAllListeners('timeout');
+    connection.removeAllListeners('parseError');
+    connection.removeAllListeners('connect');
+    connection.destroy();
     
-    if (this.index >= this.connections.length) {
-      // Go back to the beggining of the pool if capping connections
-      this.index = 0;
+    // if this connection is in the available pool, make sure it's popped off the queue
+    var index = this.available.indexOf(connection);
+    if (index > -1) {
+      this.available.splice(index, 1);
     }
+  }
+  
+  if (this.index >= this.connections.length) {
+    // Go back to the beggining of the pool if capping connections
+    this.index = 0;
+  }
 }
 
 /**

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -140,7 +140,9 @@ var connectHandler = function(self) {
  * Destroy pool
  * @method
  */
-Pool.prototype.destroy = function() {
+Pool.prototype.destroy = function(err) {
+  var self = this;
+  
   this.state = DESTROYED;
   // Set dead
   this.dead = true;
@@ -154,6 +156,9 @@ Pool.prototype.destroy = function() {
     // Destroy the connection
     c.destroy();
   });
+  
+  // pass along destroy message to flush to ensure queries pending running and closed down properly
+  if (err) { self.flush(err); }
   
   this.queryQueue = [];
   this.available = [];
@@ -309,18 +314,9 @@ Pool.prototype._processQueue = function() {
   if (self.queryQueue.length === 0 || self.available.length === 0) { return; }
   
   var query = self.queryQueue.shift();
-  var connection = self.available.pop();
+  var connection = self.available.shift();
   
-  // write our query to the selected connection
-  try {
-    connection.write(query.query.toBin());
-  } catch (err) {
-    self.available.push(connection);
-    return query.cb(MongoError.create(err));
-  }
-  
-  // register the callback
-  query.callbacks.register(query.query.requestId, function() {
+  var complete = function(err, result) {
     // make our connection available again
     self.available.push(connection);
     
@@ -331,7 +327,33 @@ Pool.prototype._processQueue = function() {
     execute(function() {
       self._processQueue();
     });
+  }
+  
+  // write our query to the selected connection
+  try {
+    connection.write(query.query.toBin());
+  } catch (err) {
+    return complete(MongoError.create(err));
+  }
+  
+  // copy values attached to the callback on to our new complete method
+  // needed for cursor issues like raw, and documentsReturnedIn
+  Object.keys(query.cb).forEach(function(val) {
+    complete[val] = query.cb[val];
   });
+  
+  query.callbacks.register(query.query.requestId, complete);
+}
+
+// Flush all pending queries
+Pool.prototype.flush = function(err) {
+  var self = this;
+  
+  self.queryQueue.forEach(function(val) {
+    val.cb(err);
+  });
+  
+  self.queryQueue = [];
 }
 
 /**

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -58,7 +58,7 @@ var Pool = function(options) {
   // Contains all connections
   this.connections = [];
   this.available = [];
-  this.monitorAvailable = [];
+  this.monitorConnection = null;
   this.state = DISCONNECTED;
   this.queryQueue = [];
   // Round robin index
@@ -132,7 +132,8 @@ var connectHandler = function(self) {
     // We have connected to all servers
     if(self.connections.length == self.size) {
       if (self.monitoring === true) {
-        self.monitorAvailable.push(self.connections[self.connections.length - 1]);
+        // set aside the last connection for the monitor
+        self.monitorConnection = self.connections[self.connections.length - 1];
       }
       
       self.state = CONNECTED;
@@ -168,7 +169,7 @@ Pool.prototype.destroy = function(err) {
   
   this.queryQueue = [];
   this.available = [];
-  this.monitorAvailable = [];
+  this.monitorConnection = null;
 }
 
 var execute = null;
@@ -247,28 +248,27 @@ Pool.prototype.get = function(options) {
  * @param {number} maxConnections reduce the poolsize to maxConnections
  */
 Pool.prototype.capConnections = function(maxConnections) {
-  // Do we have more connections than specified slice it
-  if(this.connections.length > maxConnections) {
-    // Get the rest of the connections
-    var connections = this.connections.slice(maxConnections);
-    // Cap the active connections
-    this.connections = this.connections.slice(0, maxConnections);
-
-    if (this.index >= maxConnections){
+    while(this.connections.length > maxConnections) {
+      // removes connections off the front so that our monitor socket (the last socket) is intact
+      var connection = this.connections.shift();
+      connection.removeAllListeners('close');
+      connection.removeAllListeners('error');
+      connection.removeAllListeners('timeout');
+      connection.removeAllListeners('parseError');
+      connection.removeAllListeners('connect');
+      connection.destroy();
+      
+      // if this connection is in the available pool, make sure it's popped off the queue
+      var index = this.available.indexOf(connection);
+      if (index > -1) {
+        this.available.splice(index, 1);
+      }
+    }
+    
+    if (this.index >= this.connections.length) {
       // Go back to the beggining of the pool if capping connections
       this.index = 0;
     }
-
-    // Remove all listeners
-    for(var i = 0; i < connections.length; i++) {
-      connections[i].removeAllListeners('close');
-      connections[i].removeAllListeners('error');
-      connections[i].removeAllListeners('timeout');
-      connections[i].removeAllListeners('parseError');
-      connections[i].removeAllListeners('connect');
-      connections[i].destroy();
-    }
-  }
 }
 
 /**
@@ -313,30 +313,38 @@ Pool.prototype.query = function(args, cb) {
   // args.callbacks - Callbacks to register callbacks on
   // args.monitor - Whether or not to pass to monitor socket
   
+  if (args.monitoring === true && self.monitoring === true) {
+    // execute query on the monitor socket immediately
+    return self._execute(args, self.monitorConnection, cb);
+  } else if (args.connection !== undefined) {
+    // connection specified for some reason, execute utilizing that connection
+    return self._execute(args, args.connection, cb);
+  }
+  
   args.cb = bindToCurrentDomain(cb);
+  
+  // our domain wrapped version won't have the properties, need to re-wrap or they are lost
+  self._copyFnProps(cb, args.cb);
   
   self.queryQueue.push(args);
   
   self._processQueue();
 }
 
+// Processes the queue of queries and runs one if there is a query to run and a socket available to run it
 Pool.prototype._processQueue = function() {
   var self = this;
   
   // check to see if there is queries in queue and available connections to process
-  if (self.queryQueue.length === 0) { return; }
-  
-  var possibleQuery = self.queryQueue[0];
-  var connectionPool = possibleQuery.monitoring === true && self.monitoring === true ? self.monitorAvailable : self.available;
-  
-  if (connectionPool.length === 0) { return; }
+  if (self.queryQueue.length === 0 || self.available.length === 0) { return; }
   
   var queryArgs = self.queryQueue.shift();
-  var connection = connectionPool.shift();
+  var connection = self.available.shift();
   
+  // wrap the callback so that we re-queue the connection and loop over the queue again after completion
   var complete = function(err, result) {
     // make our connection available again
-    connectionPool.push(connection);
+    self.available.push(connection);
     
     // pass the returned values to our original callback
     queryArgs.cb.apply(null, arguments);
@@ -347,6 +355,26 @@ Pool.prototype._processQueue = function() {
     });
   }
   
+  // each time we wrap the cb, we need to copy the props along
+  self._copyFnProps(complete, queryArgs.cb);
+  
+  self._execute(queryArgs, connection, complete);
+}
+
+Pool.prototype._copyFnProps = function(fromCb, toCb) {
+  var self = this;
+  
+  // copy values attached to the callback on to our new complete method
+  // needed for cursor issues like raw, and documentsReturnedIn
+  Object.keys(fromCb).forEach(function(val) {
+    toCb[val] = fromCb[val];
+  });
+}
+
+// Execute the query
+Pool.prototype._execute = function(queryArgs, connection, cb) {
+  var self = this;
+  
   // write our query to the selected connection
   try {
     connection.write(queryArgs.query.toBin());
@@ -354,13 +382,7 @@ Pool.prototype._processQueue = function() {
     return complete(MongoError.create(err));
   }
   
-  // copy values attached to the callback on to our new complete method
-  // needed for cursor issues like raw, and documentsReturnedIn
-  Object.keys(queryArgs.cb).forEach(function(val) {
-    complete[val] = queryArgs.cb[val];
-  });
-  
-  queryArgs.callbacks.register(queryArgs.query.requestId, complete);
+  queryArgs.callbacks.register(queryArgs.query.requestId, cb);
 }
 
 // Flush all pending queries

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -379,7 +379,7 @@ Pool.prototype._execute = function(queryArgs, connection, cb) {
   try {
     connection.write(queryArgs.query.toBin());
   } catch (err) {
-    return complete(MongoError.create(err));
+    return cb(MongoError.create(err));
   }
   
   queryArgs.callbacks.register(queryArgs.query.requestId, cb);

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -6,6 +6,7 @@ var inherits = require('util').inherits
   , Query = require('./commands').Query
   , Logger = require('./logger')
   , f = require('util').format
+  , MongoError = require('../error')
   , bindToCurrentDomain = require('../connection/utils').bindToCurrentDomain;
 
 var DISCONNECTED = 'disconnected';
@@ -310,6 +311,14 @@ Pool.prototype._processQueue = function() {
   var query = self.queryQueue.shift();
   var connection = self.available.pop();
   
+  // write our query to the selected connection
+  try {
+    connection.write(query.query.toBin());
+  } catch (err) {
+    self.available.push(connection);
+    return query.cb(MongoError.create(err));
+  }
+  
   // register the callback
   query.callbacks.register(query.query.requestId, function() {
     // make our connection available again
@@ -323,9 +332,6 @@ Pool.prototype._processQueue = function() {
       self._processQueue();
     });
   });
-  
-  // write our query to the selected connection
-  connection.write(query.query.toBin());
 }
 
 /**

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -5,7 +5,8 @@ var inherits = require('util').inherits
   , Connection = require('./connection')
   , Query = require('./commands').Query
   , Logger = require('./logger')
-  , f = require('util').format;
+  , f = require('util').format
+  , bindToCurrentDomain = require('../connection/utils').bindToCurrentDomain;
 
 var DISCONNECTED = 'disconnected';
 var CONNECTING = 'connecting';
@@ -55,7 +56,9 @@ var Pool = function(options) {
   if(!options.bson) throw new Error("must pass in valid bson parser");
   // Contains all connections
   this.connections = [];
+  this.available = [];
   this.state = DISCONNECTED;
+  this.queryQueue = [];
   // Round robin index
   this.index = 0;
   this.dead = false;
@@ -122,6 +125,7 @@ var parseErrorHandler = function(self) {
 var connectHandler = function(self) {
   return function(connection) {
     self.connections.push(connection);
+    self.available.push(connection);
     // We have connected to all servers
     if(self.connections.length == self.size) {
       self.state = CONNECTED;
@@ -149,6 +153,9 @@ Pool.prototype.destroy = function() {
     // Destroy the connection
     c.destroy();
   });
+  
+  this.queryQueue = [];
+  this.available = [];
 }
 
 var execute = null;
@@ -282,6 +289,44 @@ Pool.prototype.isDestroyed = function() {
   return this.state == DESTROYED;
 }
 
+/**
+ * Executes a command on the pool, waiting for the first available socket to process
+ * Abstracts the inner workings of the pool from the pool users
+ */
+Pool.prototype.query = function(query, callbacks, cb) {
+  var self = this;
+  
+  self.queryQueue.push({ query : query, callbacks : callbacks, cb : bindToCurrentDomain(cb) });
+  
+  self._processQueue();
+}
+
+Pool.prototype._processQueue = function() {
+  var self = this;
+  
+  // check to see if there is queries in queue and available connections to process
+  if (self.queryQueue.length === 0 || self.available.length === 0) { return; }
+  
+  var query = self.queryQueue.shift();
+  var connection = self.available.pop();
+  
+  // register the callback
+  query.callbacks.register(query.query.requestId, function() {
+    // make our connection available again
+    self.available.push(connection);
+    
+    // pass the returned values to our original callback
+    query.cb.apply(null, arguments);
+    
+    // bounce off the event loop and continue processing
+    execute(function() {
+      self._processQueue();
+    });
+  });
+  
+  // write our query to the selected connection
+  connection.write(query.query.toBin());
+}
 
 /**
  * A server connect event, used to verify that the connection is up and running

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -61,6 +61,7 @@ var Pool = function(options) {
   this.monitorConnection = null;
   this.state = DISCONNECTED;
   this.queryQueue = [];
+  this.queryConnections = {};
   // Round robin index
   this.index = 0;
   this.dead = false;
@@ -312,6 +313,7 @@ Pool.prototype.query = function(args, cb) {
   // args.query - Query() object to utilize
   // args.callbacks - Callbacks to register callbacks on
   // args.monitor - Whether or not to pass to monitor socket
+  // args._logConnection - Whether to store the connection for use in unit tests
   
   if (args.monitoring === true && self.monitoring === true) {
     // execute query on the monitor socket immediately
@@ -380,6 +382,11 @@ Pool.prototype._execute = function(queryArgs, connection, cb) {
     connection.write(queryArgs.query.toBin());
   } catch (err) {
     return cb(MongoError.create(err));
+  }
+  
+  if (queryArgs._logConnection) {
+    // used in unit tests to verify a connection was used
+    self.queryConnections[queryArgs.query.requestId] = connection;
   }
   
   queryArgs.callbacks.register(queryArgs.query.requestId, cb);

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -356,7 +356,7 @@ Pool.prototype._processQueue = function() {
   }
   
   // each time we wrap the cb, we need to copy the props along
-  self._copyFnProps(complete, queryArgs.cb);
+  self._copyFnProps(queryArgs.cb, complete);
   
   self._execute(queryArgs, connection, complete);
 }

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -299,10 +299,16 @@ Pool.prototype.isDestroyed = function() {
  * Executes a command on the pool, waiting for the first available socket to process
  * Abstracts the inner workings of the pool from the pool users
  */
-Pool.prototype.query = function(query, callbacks, cb) {
+Pool.prototype.query = function(args, cb) {
   var self = this;
   
-  self.queryQueue.push({ query : query, callbacks : callbacks, cb : bindToCurrentDomain(cb) });
+  // args.query - Query() object to utilize
+  // args.callbacks - Callbacks to register callbacks on
+  // args.monitor - Whether or not to pass to monitor socket
+  
+  args.cb = bindToCurrentDomain(cb);
+  
+  self.queryQueue.push(args);
   
   self._processQueue();
 }
@@ -313,7 +319,7 @@ Pool.prototype._processQueue = function() {
   // check to see if there is queries in queue and available connections to process
   if (self.queryQueue.length === 0 || self.available.length === 0) { return; }
   
-  var query = self.queryQueue.shift();
+  var queryArgs = self.queryQueue.shift();
   var connection = self.available.shift();
   
   var complete = function(err, result) {
@@ -321,7 +327,7 @@ Pool.prototype._processQueue = function() {
     self.available.push(connection);
     
     // pass the returned values to our original callback
-    query.cb.apply(null, arguments);
+    queryArgs.cb.apply(null, arguments);
     
     // bounce off the event loop and continue processing
     execute(function() {
@@ -331,18 +337,18 @@ Pool.prototype._processQueue = function() {
   
   // write our query to the selected connection
   try {
-    connection.write(query.query.toBin());
+    connection.write(queryArgs.query.toBin());
   } catch (err) {
     return complete(MongoError.create(err));
   }
   
   // copy values attached to the callback on to our new complete method
   // needed for cursor issues like raw, and documentsReturnedIn
-  Object.keys(query.cb).forEach(function(val) {
-    complete[val] = query.cb[val];
+  Object.keys(queryArgs.cb).forEach(function(val) {
+    complete[val] = queryArgs.cb[val];
   });
   
-  query.callbacks.register(query.query.requestId, complete);
+  queryArgs.callbacks.register(queryArgs.query.requestId, complete);
 }
 
 // Flush all pending queries

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -332,7 +332,7 @@ Cursor.prototype._find = function(callback) {
     queryCallback.documentsReturnedIn = self.query.documentsReturnedIn;
   }
 
-  self.server.query(self.query, queryCallback);
+  self.server.query({ query : self.query }, queryCallback);
 }
 
 Cursor.prototype._getmore = function(callback) {

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -332,11 +332,7 @@ Cursor.prototype._find = function(callback) {
     queryCallback.documentsReturnedIn = self.query.documentsReturnedIn;
   }
 
-  // Set up callback
-  self.callbacks.register(self.query.requestId, queryCallback);
-
-  // Write the initial command out
-  self.connection.write(self.query.toBin());
+  self.server.query(self.query, queryCallback);
 }
 
 Cursor.prototype._getmore = function(callback) {
@@ -352,7 +348,7 @@ Cursor.prototype._getmore = function(callback) {
   }
 
   // We have a wire protocol handler
-  this.server.wireProtocolHandler.getMore(this.bson, this.ns, this.cursorState, batchSize, raw, this.connection, this.callbacks, this.options, callback);
+  this.server.wireProtocolHandler.getMore(this.bson, this.ns, this.cursorState, batchSize, raw, this.server, this.options, callback);
 }
 
 Cursor.prototype._killcursor = function(callback) {

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -759,16 +759,8 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
 
     return;
   }
-
-  // Execute a single command query
-  try {
-    connection.write(query.toBin());
-  } catch(err) {
-    return callback(MongoError.create(err));
-  }
-
-  // Register the callback
-  self.s.callbacks.register(query.requestId, function(err, result) {
+  
+  self.query(query, function(err, result) {
     // Notify end of command
     notifyStrategies(self, self.s, 'endOperation', [self, err, result, new Date()]);
     if(err) return callback(err);
@@ -1140,6 +1132,17 @@ Server.prototype.getConnection = function(options) {
  */
 Server.prototype.getCallbacks = function() {
   return this.s.callbacks;
+}
+
+/**
+ * Execute a query on a server's pool
+ * @method
+ * @return {undefined}
+ */
+Server.prototype.query = function(query, cb) {
+  var self = this;
+  
+  self.s.pool.query(query, self.getCallbacks(), cb);
 }
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -65,6 +65,8 @@ var Callbacks = function() {
   this.id = callbackId++;
   // Set the type to server
   this.type = 'server';
+  
+  this.pool = null;
 }
 
 //
@@ -80,6 +82,9 @@ var cloneOptions = function(options) {
 //
 // Flush all callbacks
 Callbacks.prototype.flush = function(err) {
+  var self = this;
+  
+  // flush legacy callbacks
   for(var id in this.callbacks) {
     if(!isNaN(parseInt(id, 10))) {
       var callback = this.callbacks[id];
@@ -87,6 +92,10 @@ Callbacks.prototype.flush = function(err) {
       callback(err, null);
     }
   }
+  
+  // flush pool callbacks
+  // needed for legacy purposes until callbacks refactored into pool
+  self.pool.flush(err);
 }
 
 Callbacks.prototype.emit = function(id, err, value) {
@@ -169,6 +178,7 @@ var reconnectServer = function(self, state) {
   state.state = CONNECTING;
   // Create a new Pool
   state.pool = new Pool(state.options);
+  state.callbacks.pool = state.pool;
   // error handler
   var reconnectErrorHandler = function(err) {
     // Set the state to disconnected so we can peform a proper reconnect
@@ -643,6 +653,7 @@ Server.prototype.connect = function(_options) {
   if(!self.s.pool) {
     self.s.options.messageHandler = messageHandler(self, self.s);
     self.s.pool = new Pool(self.s.options);
+    self.s.callbacks.pool = self.s.pool;
   }
 
   // Add all the event handlers
@@ -674,9 +685,10 @@ Server.prototype.destroy = function(emitClose, emitDestroy) {
   // Set state as destroyed
   self.s.state = DESTROYED;
   // Close the pool
-  self.s.pool.destroy();
+  var err = new MongoError(f("server %s sockets closed", self.name))
+  self.s.pool.destroy(err);
   // Flush out all the callbacks
-  if(self.s.callbacks) self.s.callbacks.flush(new MongoError(f("server %s sockets closed", self.name)));
+  if(self.s.callbacks) self.s.callbacks.flush(err);
 }
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -772,7 +772,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
     return;
   }
   
-  self.query({ query : query }, function(err, result) {
+  self.query({ query : query, monitoring : options.monitoring }, function(err, result) {
     // Notify end of command
     notifyStrategies(self, self.s, 'endOperation', [self, err, result, new Date()]);
     if(err) return callback(err);

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -772,7 +772,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
     return;
   }
   
-  self.query(query, function(err, result) {
+  self.query({ query : query }, function(err, result) {
     // Notify end of command
     notifyStrategies(self, self.s, 'endOperation', [self, err, result, new Date()]);
     if(err) return callback(err);
@@ -1147,14 +1147,16 @@ Server.prototype.getCallbacks = function() {
 }
 
 /**
- * Execute a query on a server's pool
+ * Execute a query on a server's pool, rolling in server arguments
  * @method
  * @return {undefined}
  */
-Server.prototype.query = function(query, cb) {
+Server.prototype.query = function(args, cb) {
   var self = this;
   
-  self.s.pool.query(query, self.getCallbacks(), cb);
+  args.callbacks = self.getCallbacks();
+  
+  self.s.pool.query(args, cb);
 }
 
 /**

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -772,7 +772,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
     return;
   }
   
-  self.query({ query : query, monitoring : options.monitoring }, function(err, result) {
+  self.query({ query : query, monitoring : options.monitoring, connection : options.connection }, function(err, result) {
     // Notify end of command
     notifyStrategies(self, self.s, 'endOperation', [self, err, result, new Date()]);
     if(err) return callback(err);
@@ -781,7 +781,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
       || result.documents[0]['err']
       || result.documents[0]['code']) return callback(MongoError.create(result.documents[0]));
       // Execute callback, catch and rethrow if needed
-      try { callback(null, new CommandResult(result.documents[0], connection)); }
+      try { callback(null, new CommandResult(result.documents[0], options.connection)); }
       catch(err) { process.nextTick(function() { throw err}); }
   });
 }

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -772,7 +772,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
     return;
   }
   
-  self.query({ query : query, monitoring : options.monitoring, connection : options.connection }, function(err, result) {
+  self.query({ query : query, monitoring : options.monitoring, connection : options.connection, _logConnection : options._logConnection }, function(err, result) {
     // Notify end of command
     notifyStrategies(self, self.s, 'endOperation', [self, err, result, new Date()]);
     if(err) return callback(err);
@@ -781,7 +781,7 @@ var executeSingleOperation = function(self, ns, cmd, queryOptions, options, onAl
       || result.documents[0]['err']
       || result.documents[0]['code']) return callback(MongoError.create(result.documents[0]));
       // Execute callback, catch and rethrow if needed
-      try { callback(null, new CommandResult(result.documents[0], options.connection)); }
+      try { callback(null, new CommandResult(result.documents[0], self.s.pool.queryConnections[query.requestId])); }
       catch(err) { process.nextTick(function() { throw err}); }
   });
 }

--- a/lib/wireprotocol/2_4_support.js
+++ b/lib/wireprotocol/2_4_support.js
@@ -89,7 +89,7 @@ WireProtocol.prototype.killCursor = function(bson, ns, cursorId, connection, cal
   if(callback) callback(null, null);
 }
 
-WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, connection, callbacks, options, callback) {
+WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, topology, options, callback) {
   // Create getMore command
   var getMore = new GetMore(bson, ns, cursorState.cursorId, {numberToReturn: batchSize});
 
@@ -120,10 +120,8 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
     queryCallback.raw = raw;
   }
 
-  // Register a callback
-  callbacks.register(getMore.requestId, queryCallback);
-  // Write out the getMore command
-  connection.write(getMore.toBin());
+  // execute the query on the toplogy
+  topology.query(getMore, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/2_4_support.js
+++ b/lib/wireprotocol/2_4_support.js
@@ -121,7 +121,7 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   }
 
   // execute the query on the toplogy
-  topology.query(getMore, queryCallback);
+  topology.query({ query : getMore }, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -111,7 +111,7 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   }
   
   // execute the query on the toplogy
-  topology.query(getMore, queryCallback);
+  topology.query({ query : getMore }, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -48,6 +48,7 @@ var executeWrite = function(topology, type, opsField, ns, ops, options, callback
   // Ensure we support serialization of functions
   if(options.serializeFunctions) opts.serializeFunctions = options.serializeFunctions;
   if(options.ignoreUndefined) opts.ignoreUndefined = options.ignoreUndefined;
+  if(options._logConnection) opts._logConnection = options._logConnection;
   // Execute command
   topology.command(f("%s.$cmd", d), writeCommand, opts, callback);
 }

--- a/lib/wireprotocol/2_6_support.js
+++ b/lib/wireprotocol/2_6_support.js
@@ -79,7 +79,7 @@ WireProtocol.prototype.killCursor = function(bson, ns, cursorId, connection, cal
   if(callback) callback(null, null);
 }
 
-WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, connection, callbacks, options, callback) {
+WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, topology, options, callback) {
   // Create getMore command
   var getMore = new GetMore(bson, ns, cursorState.cursorId, {numberToReturn: batchSize});
 
@@ -109,11 +109,9 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   if(raw) {
     queryCallback.raw = raw;
   }
-
-  // Register a callback
-  callbacks.register(getMore.requestId, queryCallback);
-  // Write out the getMore command
-  connection.write(getMore.toBin());
+  
+  // execute the query on the toplogy
+  topology.query(getMore, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -208,7 +208,7 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   queryCallback.documentsReturnedIn = 'nextBatch';
 
   // execute the query on the toplogy
-  topology.query(getMore, queryCallback);
+  topology.query(query, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -129,7 +129,7 @@ WireProtocol.prototype.killCursor = function(bson, ns, cursorId, connection, cal
   callbacks.register(query.requestId, killCursorCallback);
 }
 
-WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, connection, callbacks, options, callback) {
+WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw, topology, options, callback) {
   var readPreference = options.readPreference || new ReadPreference('primary');
   if(typeof readPreference == 'string') readPreference = new ReadPreference(readPreference);
   if(!(readPreference instanceof ReadPreference)) throw new MongoError('readPreference must be a ReadPreference instance');
@@ -207,10 +207,8 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   // Add the result field needed
   queryCallback.documentsReturnedIn = 'nextBatch';
 
-  // Register a callback
-  callbacks.register(query.requestId, queryCallback);
-  // Write out the getMore command
-  connection.write(query.toBin());
+  // execute the query on the toplogy
+  topology.query(getMore, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -208,7 +208,7 @@ WireProtocol.prototype.getMore = function(bson, ns, cursorState, batchSize, raw,
   queryCallback.documentsReturnedIn = 'nextBatch';
 
   // execute the query on the toplogy
-  topology.query(query, queryCallback);
+  topology.query({ query : query }, queryCallback);
 }
 
 WireProtocol.prototype.command = function(bson, ns, cmd, cursorState, topology, options) {

--- a/lib/wireprotocol/3_2_support.js
+++ b/lib/wireprotocol/3_2_support.js
@@ -56,6 +56,7 @@ var executeWrite = function(topology, type, opsField, ns, ops, options, callback
   // Ensure we support serialization of functions
   if(options.serializeFunctions) opts.serializeFunctions = options.serializeFunctions;
   if(options.ignoreUndefined) opts.ignoreUndefined = options.ignoreUndefined;
+  if(options._logConnection) opts._logConnection = options._logConnection;
   // Execute command
   topology.command(f("%s.$cmd", d), writeCommand, opts, callback);
 }

--- a/test/tests/functional/basic_auth_tests.js
+++ b/test/tests/functional/basic_auth_tests.js
@@ -43,7 +43,7 @@ exports['Simple authentication test for single server'] = {
         , roles: ['dbOwner']
         , digestPassword: false
         , writeConcern: {w:1}
-      }, function(err, r) {
+      }, {_logConnection:true}, function(err, r) {
         test.equal(null, err);
         test.equal(1, r.result.ok);
         // Grab the connection
@@ -124,7 +124,7 @@ exports['Simple authentication test for replicaset'] = {
         , roles: ['dbOwner']
         , digestPassword: false
         , writeConcern: {w:'majority'}
-      }, function(err, r) {
+      }, {_logConnection:true}, function(err, r) {
         test.equal(null, err);
         test.equal(1, r.result.ok);
         // Grab the connection
@@ -207,7 +207,7 @@ exports['Simple authentication test for mongos'] = {
         , roles: ['dbOwner']
         , digestPassword: false
         , writeConcern: {w:1}
-      }, function(err, r) {
+      }, {_logConnection:true}, function(err, r) {
         test.equal(null, err);
         test.equal(1, r.result.ok);
         // Grab the connection

--- a/test/tests/functional/mongos_mocks/multiple_proxies_tests.js
+++ b/test/tests/functional/mongos_mocks/multiple_proxies_tests.js
@@ -104,15 +104,15 @@ exports['Should correctly load-balance the operations'] = {
 
       // Add event listeners
       server.once('connect', function(_server) {
-        _server.insert('test.test', [{created:new Date()}], function(err, r) {
+        _server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
           test.equal(null, err);
           test.equal(52000, r.connection.port);
 
-          _server.insert('test.test', [{created:new Date()}], function(err, r) {
+          _server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
             test.equal(null, err);
             test.equal(52001, r.connection.port);
 
-            _server.insert('test.test', [{created:new Date()}], function(err, r) {
+            _server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
               test.equal(null, err);
               test.equal(52000, r.connection.port);
 
@@ -233,11 +233,11 @@ exports['Should ignore one of the mongos instances due to being outside the late
 
     // Add event listeners
     server.once('fullsetup', function(_server) {
-      server.insert('test.test', [{created:new Date()}], function(err, r) {
+      server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
         test.equal(null, err);
         test.equal(52000, r.connection.port);
 
-        server.insert('test.test', [{created:new Date()}], function(err, r) {
+        server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
           test.equal(null, err);
           test.equal(52000, r.connection.port);
 
@@ -257,11 +257,11 @@ exports['Should ignore one of the mongos instances due to being outside the late
 
           // Add event listeners
           server2.once('fullsetup', function(_server) {
-            server2.insert('test.test', [{created:new Date()}], function(err, r) {
+            server2.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
               test.equal(null, err);
               test.equal(52001, r.connection.port);
 
-              server2.insert('test.test', [{created:new Date()}], function(err, r) {
+              server2.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
                 test.equal(null, err);
                 test.equal(52000, r.connection.port);
 

--- a/test/tests/functional/mongos_mocks/proxy_failover_tests.js
+++ b/test/tests/functional/mongos_mocks/proxy_failover_tests.js
@@ -107,7 +107,7 @@ exports['Should correctly failover due to proxy going away causing timeout'] = {
     // Add event listeners
     server.once('fullsetup', function(_server) {
       var intervalId = setInterval(function() {
-        server.insert('test.test', [{created:new Date()}], function(err, r) {
+        server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
           // If we have a successful insert
           // validate that it's the expected proxy
           if(r) {
@@ -231,7 +231,7 @@ exports['Should correctly bring back proxy and use it'] = {
     // Add event listeners
     server.once('fullsetup', function(_server) {
       var intervalId = setInterval(function() {
-        server.insert('test.test', [{created:new Date()}], function(err, r) {
+        server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
           // If we have a successful insert
           // validate that it's the expected proxy
           if(r) {
@@ -246,7 +246,7 @@ exports['Should correctly bring back proxy and use it'] = {
               // Bring back the missing proxy
               if(currentStep == 0) currentStep = currentStep + 1;
               // Perform inserts
-              server.insert('test.test', [{created:new Date()}], function(err, r) {
+              server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
                 if(r) {
                   proxies[r.connection.port] = true
                 }
@@ -393,7 +393,7 @@ exports['Should correctly bring back both proxies and use it'] = {
           // Perform interval inserts waiting for both proxies to come back
           var intervalId2 = setInterval(function() {
             // Perform inserts
-            server.insert('test.test', [{created:new Date()}], function(err, r) {
+            server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
               if(intervalId2 == null) return;
               if(r) {
                 proxies[r.connection.port] = true

--- a/test/tests/functional/mongos_mocks/single_proxy_connection_tests.js
+++ b/test/tests/functional/mongos_mocks/single_proxy_connection_tests.js
@@ -104,7 +104,7 @@ exports['Should correctly timeout mongos socket operation and then correctly re-
     _server.once('connect', function() {
       // Run an interval
       var intervalId = setInterval(function() {
-        _server.insert('test.test', [{created:new Date()}], function(err, r) {
+        _server.insert('test.test', [{created:new Date()}], { _logConnection : true }, function(err, r) {
           if(r && !done) {
             done = true;
             clearInterval(intervalId);

--- a/test/tests/functional/rs_mocks/connection_tests.js
+++ b/test/tests/functional/rs_mocks/connection_tests.js
@@ -450,7 +450,7 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
         running = false;
 
         test.done();
-      }, 10);
+      }, 100);
     });
 
     // Add event listeners

--- a/test/tests/functional/rs_mocks/connection_tests.js
+++ b/test/tests/functional/rs_mocks/connection_tests.js
@@ -433,12 +433,9 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
         secondaryOnlyConnectionAllowed: true
     });
 
-    server.on('joined', function(_type) {
-      joined++;
-      
-      if (joined === 2) {
-        test.equal(true, server.__connected);
-
+    server.on('connect', function(e) {
+      // connect can sometimes be fired before all of the servers have joined, so we have to timeout to avoid race conditions
+      setTimeout(function() {
         test.equal(1, server.s.replState.secondaries.length);
         test.equal('localhost:32001', server.s.replState.secondaries[0].name);
 
@@ -453,11 +450,7 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
         running = false;
 
         test.done();
-      }
-    });
-
-    server.on('connect', function(e) {
-      server.__connected = true;
+      }, 10);
     });
 
     // Add event listeners

--- a/test/tests/functional/rs_mocks/connection_tests.js
+++ b/test/tests/functional/rs_mocks/connection_tests.js
@@ -366,6 +366,7 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
     var arbiterServer = null;
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
+    var joined = 0;
 
     // Default message fields
     var defaultFields = {
@@ -433,7 +434,9 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
     });
 
     server.on('joined', function(_type) {
-      if(_type == 'arbiter') {
+      joined++;
+      
+      if (joined === 2) {
         test.equal(true, server.__connected);
 
         test.equal(1, server.s.replState.secondaries.length);
@@ -449,7 +452,7 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
         server.destroy();
         running = false;
 
-        test.done();        
+        test.done();
       }
     });
 

--- a/test/tests/functional/rs_mocks/monitoring_tests.js
+++ b/test/tests/functional/rs_mocks/monitoring_tests.js
@@ -160,7 +160,7 @@ exports['Should correctly connect to a replicaset where the primary hangs causin
             // if(r) console.log(r.connection.port)
 
             // Did we switch servers
-            if(r && r.connection.port == 32001) {
+            if(r && _server.s.replState.primary.s.serverDetails.port === 32001) {
               test.ok(stopRespondingPrimary);
               test.equal(1, currentIsMasterState);
 

--- a/test/tests/functional/rs_mocks/read_preferences_tests.js
+++ b/test/tests/functional/rs_mocks/read_preferences_tests.js
@@ -125,7 +125,8 @@ exports['Should correctly connect to a replicaset and select the correct tagged 
               count: 'test.test'
             , batchSize: 2
           }, {
-            readPreference: new ReadPreference('secondaryPreferred', {loc:'dc'})
+            readPreference: new ReadPreference('secondaryPreferred', {loc:'dc'}),
+            _logConnection : true
           }, function(err, r) {
             test.equal(err, null);
             test.equal(32002, r.connection.port);
@@ -277,7 +278,8 @@ exports['Should correctly connect to a replicaset and select the primary server'
               count: 'test.test'
             , batchSize: 2
           }, {
-            readPreference: new ReadPreference('primaryPreferred')
+            readPreference: new ReadPreference('primaryPreferred'),
+            _logConnection : true
           }, function(err, r) {
             test.equal(err, null);
             test.equal(32000, r.connection.port);
@@ -429,7 +431,8 @@ exports['Should correctly round robin secondary reads'] = {
               count: 'test.test'
             , batchSize: 2
           }, {
-            readPreference: new ReadPreference('secondary')
+            readPreference: new ReadPreference('secondary'),
+            _logConnection : true
           }, function(err, r) {
             test.equal(err, null);
             test.equal(32002, r.connection.port);
@@ -439,7 +442,8 @@ exports['Should correctly round robin secondary reads'] = {
                 count: 'test.test'
               , batchSize: 2
             }, {
-              readPreference: new ReadPreference('secondary')
+              readPreference: new ReadPreference('secondary'),
+              _logConnection : true
             }, function(err, r) {
               test.equal(err, null);
               test.equal(32001, r.connection.port);
@@ -449,7 +453,8 @@ exports['Should correctly round robin secondary reads'] = {
                   count: 'test.test'
                 , batchSize: 2
               }, {
-                readPreference: new ReadPreference('secondary')
+                readPreference: new ReadPreference('secondary'),
+                _logConnection : true
               }, function(err, r) {
                 test.equal(err, null);
                 test.equal(32002, r.connection.port);
@@ -592,7 +597,8 @@ exports['Should correctly fall back to a secondary server if the readPreference 
               count: 'test.test'
             , batchSize: 2
           }, {
-            readPreference: new ReadPreference('primaryPreferred')
+            readPreference: new ReadPreference('primaryPreferred'),
+            _logConnection: true
           }, function(err, r) {
             test.equal(err, null);
             test.equal(32000, r.connection.port);
@@ -605,7 +611,8 @@ exports['Should correctly fall back to a secondary server if the readPreference 
                     count: 'test.test'
                     , batchSize: 2
                 }, {
-                  readPreference: new ReadPreference('primaryPreferred')
+                  readPreference: new ReadPreference('primaryPreferred'),
+                  _logConnection: true
                 }, function(err, r) {
                   test.equal(err, null);
                   test.equal(32001, r.connection.port); // reads from secondary while primary down
@@ -766,7 +773,8 @@ exports['Should correctly fallback to secondaries when primary not available'] =
                 count: 'test.test'
               , batchSize: 2
             }, {
-              readPreference: new ReadPreference('primaryPreferred')
+              readPreference: new ReadPreference('primaryPreferred'),
+              _logConnection: true
             }, function(err, r) {
               test.equal(null, err);
               test.ok(r.connection.port != 32000);
@@ -776,7 +784,8 @@ exports['Should correctly fallback to secondaries when primary not available'] =
                   count: 'test.test'
                 , batchSize: 2
               }, {
-                readPreference: new ReadPreference('secondaryPreferred')
+                readPreference: new ReadPreference('secondaryPreferred'),
+                _logConnection: true
               }, function(err, r) {
                 test.equal(null, err);
                 test.ok(r.connection.port != 32000);

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -28,8 +28,10 @@ exports['Should correctly reconnect to server with automatic reconnect enabled']
 
     // Add event listeners
     server.on('connect', function(_server) {
+      var connection = _server.s.pool.connections[0];
+      
       // Execute the command
-      _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary')}, function(err, result) {
+      _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary'), connection: connection}, function(err, result) {
         test.equal(null, err)
         _server.s.currentReconnectRetry = 10;
 
@@ -37,13 +39,13 @@ exports['Should correctly reconnect to server with automatic reconnect enabled']
         try {
           var a = new Buffer(100);
           for(var i = 0; i < 100; i++) a[i] = i;
-          result.connection.write(a);
+          connection.write(a);
         } catch(err) {}
 
         // Ensure the server died
         setTimeout(function() {
           // Attempt a proper command
-          _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary')}, function(err, result) {
+          _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary'), connection: connection}, function(err, result) {
             test.ok(err != null);
           });          
         }, 100);
@@ -93,17 +95,19 @@ exports['Should correctly reconnect to server with automatic reconnect disabled'
 
     // Add event listeners
     server.on('connect', function(_server) {
+      var connection = server.s.pool.connections[0];
+      
       // Execute the command
-      _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary')}, function(err, result) {
+      _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary'), connection: connection}, function(err, result) {
         test.equal(null, err)
         // Write garbage, force socket closure
         try {
-          result.connection.destroy();
+          connection.destroy();
         } catch(err) {}
 
         process.nextTick(function() {
           // Attempt a proper command
-          _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary')}, function(err, result) {
+          _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary'), connection: connection}, function(err, result) {
             test.ok(err != null);
           });
         });

--- a/test/tests/functional/single_mocks/timeout_tests.js
+++ b/test/tests/functional/single_mocks/timeout_tests.js
@@ -104,7 +104,7 @@ exports['Should correctly timeout socket operation and then correctly re-execute
 
         // Run an interval
         var intervalId = setInterval(function() {
-          _server.insert('test.test', [{created:new Date()}], function(err, r) {
+          _server.insert('test.test', [{created:new Date()}], {_logConnection:true}, function(err, r) {
             if(r && !done) {
               done = true;
               clearInterval(intervalId);


### PR DESCRIPTION
This is the initial implementation for a pool that uses a queue worker as opposed to a round robin strategy. It works in a non-destructive fashion so that we didn't have to refactor the code base in entirety to handle the new pattern, rather we can gradually switch over component by component to the new mechanism until all commands are eventually migrated. This is meant for review, and then I'll circle back and correct issues or disagreements.

In example, in this current pull request I've utilized the strategy for initial cursor, getMore cursor, and Server.command.

Basically when a query comes in, it stashes the callback and the query in a queue and then executes to process the queue. If there is a connection available, it will have that connection process it, upon completion of another query, it will also process the queue.

Here is an example of the test script I used: https://gist.github.com/owenallenaz/f5a8497e977c45d013ff 

If you execute that script before my pull, you'll see many queries stall behind the slowFn. Using my pull request all of the queries will execute instantly and none of them will stall behind the slowFn, allowing for a much more efficient use of the connection pool.

Here are some outstanding issues that still need to be addressed:

1. I'm not familiar with the exhaust component of the cursor, I left that area untouched. How do I reproduce an exhaust cursor.

2. For the monitor, it seems to me the easiest way to maintain the HA monitor would be to have it's own connection pool of size 1, instead of having a reserved connection on the main pool. In this way we abstract away the complications of the monitor pool away from the operations of our main pool. What are your thoughts?

3. Is there a reason the monitor is implemented with a setTimeout in many different places in the code instead of a single setInterval? It seems like it would make a lot of that pathway much simpler.

4. Why is it that if a single net.connection in a pool errors or times out the whole pool dies? Shouldn't the pool regenerate one connection at a time, rather than killing the entirety of the pool off on a single connection error?

5. In cursor, execInitialQuery seems like dead code. Was it left behind for a reason, or could I remove?

6. What is the purpose of the onAll capability. I could not find reference to queries utilizing this. Is it entirely for auth?

All of the above issues aside, the only piece that prevents this pull request from being integrated is the monitoring component as it currently does not address that. So let me know your thoughts and I can finish that piece up. 