### PR TITLE
auth/sspi: remove annoying console.dir(err)

### DIFF
--- a/lib/auth/sspi.js
+++ b/lib/auth/sspi.js
@@ -27,9 +27,7 @@ try {
   Kerberos = require_optional('kerberos').Kerberos
   // Authentication process for Mongo
   MongoAuthProcess = require_optional('kerberos').processes.MongoAuthProcess
-} catch(err) {
-  console.dir(err)
-}
+} catch(err) {}
 
 /**
  * Creates a new SSPI authentication mechanism


### PR DESCRIPTION
coworkers think this is an error. don't need to log it. it would also be nicer if you used `console.error(err.stack)` instead so that we know where the error is coming from, but that's a different issue.