### PR TITLE
emit connect event when server reconnects after initial connection failed

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -213,6 +213,9 @@ var reconnectServer = function(self, state) {
         count = count - 1;
         // We are done, emit reconnect event
         if(count == 0) {
+          if (!state.ismaster) {
+            return connectHandler(self, state)();
+          }
           return self.emit('reconnect', self);
         }
       });

--- a/test/tests/functional/server_tests.js
+++ b/test/tests/functional/server_tests.js
@@ -7,7 +7,7 @@ exports['Should correctly reconnect to server with automatic reconnect enabled']
   metadata: {
     requires: {
       topology: "single"
-    }, 
+    },
     ignore: { travis:true }
   },
 
@@ -45,7 +45,7 @@ exports['Should correctly reconnect to server with automatic reconnect enabled']
           // Attempt a proper command
           _server.command("system.$cmd", {ismaster: true}, {readPreference: new ReadPreference('primary')}, function(err, result) {
             test.ok(err != null);
-          });          
+          });
         }, 100);
       });
     });
@@ -71,7 +71,7 @@ exports['Should correctly reconnect to server with automatic reconnect disabled'
   metadata: {
     requires: {
       topology: "single"
-    }, 
+    },
     ignore: { travis:true }
   },
 
@@ -129,3 +129,39 @@ exports['Should correctly reconnect to server with automatic reconnect disabled'
     server.connect();
   }
 }
+
+exports['Should reconnect when initial connection failed'] = {
+  metadata: {
+    requires: {
+      topology: 'single'
+    },
+    ignore: { travis:true }
+  },
+
+  test: function(configuration, test) {
+    var Server = configuration.require.Server
+      , ReadPreference = configuration.require.ReadPreference
+      , manager = configuration.manager;
+
+    manager.stop('SIGINT').then(function() {
+      // Attempt to connect while server is down
+      var server = new Server({
+          host: configuration.host
+        , port: configuration.port
+        , reconnect: true
+        , size: 1
+        , emitError: true
+      });
+
+      server.on('connect', function() {
+        test.done();
+      });
+
+      server.once('error', function() {
+        manager.start().then(function() {});
+      });
+
+      server.connect();
+    })
+  }
+};


### PR DESCRIPTION
Re: Automattic/mongoose#1774 . If reconnect is on, server tries to reconnect when initial connection fails, but when it reconnects the server object will be in a broken state because it doesn't have a `wireProtocolHandler`