### PR TITLE
Fix reconnection error after first reconnection.

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -196,10 +196,10 @@ var reconnectServer = function(self, state) {
     state.state = CONNECTED;
 
     // Add proper handlers
-    state.pool.once('error', reconnectErrorHandler);
-    state.pool.once('close', closeHandler(self, state));
-    state.pool.once('timeout', timeoutHandler(self, state));
-    state.pool.once('parseError', fatalErrorHandler(self, state));
+    state.pool.on('error', reconnectErrorHandler);
+    state.pool.on('close', closeHandler(self, state));
+    state.pool.on('timeout', timeoutHandler(self, state));
+    state.pool.on('parseError', fatalErrorHandler(self, state));
 
     // We need to ensure we have re-authenticated
     var keys = Object.keys(state.authProviders);


### PR DESCRIPTION
After the second consecutive mongodb failure, the driver does not reconnect properly. To reproduce the bug you can execute the following script:

```js
const mongodb = require('mongodb');
const MongoClient = mongodb.MongoClient;

function randomIndex() {
  return Math.ceil(Math.random() * 2100);
}

MongoClient.connect('mongodb://localhost/somedb').then(db => {
  let collection = db.collection('somecollection');
  db.on('close', err => console.log('close', err));
  db.on('reconnect', () => console.trace('reconnect'));

  setInterval(() => {
    collection.find({
      index: randomIndex()
    }).limit(1).next()
      .then(console.log)
      .catch(console.log);
  }, 1000);
});
```

With the script running execute the following steps:
- Start mongodb
- Start script
- Stop mongodb
- Restart mongodb
- Stop mongodb
- Restart mongodb

After executing these steps, the script is not connected anymore. But if I restart the script it works properly.

My commit in this pull request seems to solve the problem in my script. But I could not got through the entire code and check if my changes have some side effects.
