### PR TITLE
fix: only call unref if it exists

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -438,7 +438,9 @@ Connection.prototype.unref = function() {
  */
 Connection.prototype.destroy = function() {
   if(this.connection) {
-    this.connection.unref();
+    if (this.connection.unref) {
+      this.connection.unref();
+    }
     this.connection.end();
     this.connection.destroy();
   }


### PR DESCRIPTION
Getting a lot of these errors in node 0.10:

```
Uncaught TypeError: Object #<CleartextStream> has no method 'unref'
      at Connection.destroy (node_modules/mongodb/node_modules/mongodb-core/lib/connection/connection.js:441:21)
      at null.<anonymous> (node_modules/mongodb/node_modules/mongodb-core/lib/connection/pool.js:114:16)
      at CleartextStream.<anonymous> (node_modules/mongodb/node_modules/mongodb-core/lib/connection/connection.js:144:49)
```

Looks like crypto streams don't have `unref()` in node 0.10: https://github.com/nodejs/node/blob/d6859151a49e6558316dff5620d3ebc4788bc148/lib/tls.js 