### PR TITLE
Fix retry mechanism throwing an error on each retry and not on retry failure.

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -199,7 +199,7 @@ var reconnectServer = function(self, state) {
     // No more retries
     if(state.currentReconnectRetry <= 0) {
       self.state = DESTROYED;
-      self.emit('error', f('failed to connect to %s:%s after %s retries', state.options.host, state.options.port, state.reconnectTries));
+      self.emit('error', new MongoError(f('failed to connect to %s:%s after %s retries', state.options.host, state.options.port, state.reconnectTries)), self);
     } else {
       setTimeout(function() {
         reconnectServer(self, state);
@@ -225,7 +225,7 @@ var reconnectServer = function(self, state) {
     state.state = CONNECTED;
 
     // Add proper handlers
-    state.pool.on('error', reconnectErrorHandler);
+    state.pool.on('error', errorHandler(self, state));
     state.pool.on('close', closeHandler(self, state));
     state.pool.on('timeout', timeoutHandler(self, state));
     state.pool.on('parseError', fatalErrorHandler(self, state));
@@ -256,7 +256,7 @@ var reconnectServer = function(self, state) {
 
   //
   // Handle connection failure
-  state.pool.once('error', errorHandler(self, state));
+  state.pool.once('error', reconnectErrorHandler);
   state.pool.once('close', errorHandler(self, state));
   state.pool.once('timeout', errorHandler(self, state));
   state.pool.once('parseError', errorHandler(self, state));

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -194,13 +194,13 @@ var reconnectServer = function(self, state) {
     state.state = DISCONNECTED;
     // Destroy the pool
     state.pool.destroy();
-    // Adjust the number of retries
-    state.currentReconnectRetry = state.currentReconnectRetry - 1;
     // No more retries
-    if(state.currentReconnectRetry <= 0) {
+    if(state.currentReconnectRetry == 0) {
       self.state = DESTROYED;
       self.emit('error', new MongoError(f('failed to connect to %s:%s after %s retries', state.options.host, state.options.port, state.reconnectTries)), self);
     } else {
+      // Adjust the number of retries
+      state.currentReconnectRetry = state.currentReconnectRetry - 1;
       setTimeout(function() {
         reconnectServer(self, state);
       }, state.reconnectInterval);


### PR DESCRIPTION
This PR fixes an issue that, the driver emits an error when each retry fails and doesn't emit an error when retries reach the limit, and driver stops retry.

After this PR, each retry doesn't emit an error, and error is only emitted when retries fails after reaching retry limit.

`reconnectErrorHandler` was being used when an already established
connection errors out, however this should be used instead when a retry
errors out.