### PR TITLE
Fix retry issue introduced in a #91

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -199,8 +199,6 @@ var reconnectServer = function(self, state) {
       self.state = DESTROYED;
       self.emit('error', new MongoError(f('failed to connect to %s:%s after %s retries', state.options.host, state.options.port, state.reconnectTries)), self);
     } else {
-      // Adjust the number of retries
-      state.currentReconnectRetry = state.currentReconnectRetry - 1;
       setTimeout(function() {
         reconnectServer(self, state);
       }, state.reconnectInterval);


### PR DESCRIPTION
After https://github.com/christkv/mongodb-core/pull/91 every retry after 1st retry decrement retry counter twice for every retry, once in `reconnectErrorHandler` and again in `reconnectServer`. This PR fixes this behaviour.