### PR TITLE
docs: add explain option to cursor

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -59,6 +59,7 @@ var Long = require('bson').Long
  * @param {object} [options.transforms=null] Transform methods for the cursor results
  * @param {function} [options.transforms.query] Transform the value returned from the initial query
  * @param {function} [options.transforms.doc] Transform each document returned from Cursor.prototype.next
+ * @param {boolean} [options.explain=false] Explain the query execution rather than return the actual results
  * @param {object} topology The server topology instance.
  * @param {object} topologyOptions The server topology options.
  * @return {Cursor} A cursor instance


### PR DESCRIPTION
Technically `explain` is a valid option to the cursor constructor, at least against mongodb 3.0, [see example](https://github.com/vkarpov15/mongoose-explain/blob/091832daf622ec93ce97dc2691ce68b5e08a73d4/index.js#L24-L26). Is this formally supported or an accident?