### PR TITLE
Pool gets stuck if a connection marked for immediateRelease times out

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -373,6 +373,7 @@ var _execute = function(self) {
         // Fire and forgot message
         if(workItem.immediateRelease) {
           self.availableConnections.push(connection);
+          self.inUseConnections.pop();
         }
       }
     }

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -227,6 +227,10 @@ Pool.prototype.connect = function(_options) {
       return connection.destroy();
     }
 
+    if(self.state == CONNECTING) {
+      self.state = CONNECTED;
+    }
+
     // Add the connection to the list of available connections
     self.availableConnections.push(connection);
     // Emit connected event

--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -223,7 +223,7 @@ Pool.prototype.connect = function(_options) {
   connection.once('timeout', timeoutHandler(self));
   connection.once('parseError', parseErrorHandler(self));
   connection.on('connect', function(connection) {
-    if(self.state == 'DESTROYED') {
+    if(self.state == DESTROYED) {
       return connection.destroy();
     }
 
@@ -260,7 +260,7 @@ var _createConnection = function(self) {
   // Handle successful connection
   var tempConnectHandler = function(_connection) {
     return function() {
-      if(self.state == 'DESTROYED') {
+      if(self.state == DESTROYED) {
         // Remove the connection from the connectingConnections
         var index = self.connectingConnections.indexOf(_connection);
         if(index != -1) {
@@ -311,7 +311,7 @@ var _createConnection = function(self) {
 
 var _execute = function(self) {
   return function() {
-    if(self.state == 'DESTROYED') return;
+    if(self.state == DESTROYED) return;
     // Already executing, skip
     if(self.executing) return;
     // Set pool as executing


### PR DESCRIPTION
since that connection is still in the connectingConnections array, getAll() returns 1 connection and doesn't restart the pool.
However pool.isConnected() returns false since connection.isConnected() returns false and pool.state was left as CONNECTING. All new work gets deferred on the disconnectHandler waiting for reconnection which will never happen.