### PR TITLE
Avoid TypeError: currentLogger is not a function

### DIFF
--- a/lib/connection/logger.js
+++ b/lib/connection/logger.js
@@ -30,9 +30,8 @@ var Logger = function(className, options) {
   this.className = className;
 
   // Current logger
-  if(currentLogger == null && options.logger) {
-    currentLogger = options.logger;
-  } else if(options.logger) {
+  if(options.logger) {
+    if(typeof options.logger != 'function') throw new MongoError("options.logger must be a function");
     currentLogger = options.logger;
   } else if(currentLogger == null) {
     currentLogger = console.log;

--- a/test/tests/functional/pool_tests.js
+++ b/test/tests/functional/pool_tests.js
@@ -28,3 +28,87 @@ exports['Should correctly connect pool to single server'] = {
     pool.connect();
   }
 }
+
+exports['Should not leak connection marked as immediateRelease'] = {
+  metadata: {
+    requires: {
+      topology: "single"
+    }
+  },
+
+  test: function(configuration, test) {
+    var Server = configuration.require.Server
+      , f = require('util').format;
+
+    // Attempt to connect
+    var server = new Server({
+        host: configuration.host
+      , port: configuration.port
+      , socketTimeout: 1000
+      , size: 3
+      , reconnectInterval: 5000
+    });
+
+    // Add event listeners
+    server.on('connect', function(_server) {
+      // Insert some data
+      var ns = f("%s.immediateRelease1", configuration.db);
+      _server.insert(ns, [{a:1}, {a:2}, {a:3}], {
+        writeConcern: {w:1}, ordered:true
+      }, function(err, results) {
+        test.equal(null, err);
+        test.equal(3, results.result.n);
+
+        // Execute find
+        var cursor1 = _server.cursor(ns, {
+            find: ns
+          , query: {}
+          , batchSize: 2
+        });
+        cursor1.next(function(err, r1) {
+          test.equal(null, err);
+          test.equal(1, _server.s.pool.getAll().length);
+
+          cursor1.next(function(err, r1) {
+            test.equal(null, err);
+            test.equal(1, _server.s.pool.getAll().length);
+
+            var cursor2 = _server.cursor(ns, {
+                find: ns
+              , query: {}
+              , batchSize: 2
+            });
+            cursor2.next(function (err, r2) {
+              test.equal(null, err);
+              test.equal(1, _server.s.pool.getAll().length);
+
+              // kill cursor -- uses an immediateRelease connection
+              cursor2.kill(function (err) {
+                test.equal(null, err);
+                test.equal(1, _server.s.pool.getAll().length);
+
+                // wait for socketTimeout to destroy connection
+                setTimeout(function() {
+                  test.equal(0, _server.s.pool.getAll().length);
+
+                  // continue find -- a new connection should be created
+                  cursor1.next(function (err, r1) {
+                    test.equal(null, err);
+                    test.equal(1, _server.s.pool.getAll().length);
+
+                    _server.destroy();
+                    test.done();
+                  });
+                }, 2000);
+              });
+            });
+          });
+        });
+      });
+    });
+
+    // Start connection
+    server.connect();
+  }
+}
+


### PR DESCRIPTION
```
at Logger.debug (node_modules/mongodb/node_modules/mongodb-core/lib/connection/logger.js:74:5)
at new Connection (node_modules/mongodb/node_modules/mongodb-core/lib/connection/connection.js:68:41)
at Pool.connect (node_modules/mongodb/node_modules/mongodb-core/lib/connection/pool.js:225:20)
at Server.connect (node_modules/mongodb/node_modules/mongodb-core/lib/topologies/server.js:1010:15)
at Server.connect (node_modules/mongodb/lib/server.js:318:17)
at open (node_modules/mongodb/lib/db.js:235:19)
at Db.open (node_modules/mongodb/lib/db.js:258:44)
```

When using options.logger