### PR TITLE
Possible fix for #105

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -476,7 +476,7 @@ Pool.prototype.get = function(options) {
   if(connections.length == 1) {
     return connections[0];
   } else {
-    this.index = this.index % connections.length;
+    this.index = this.index % connections.length || 0;
     return connections[this.index];
   }
 }


### PR DESCRIPTION
This ensures Pool#index is always valid (or at least never NaN). An undefined connectionId property will still be passed to the APM event handlers if they're called before any connections have been established, but this fixes the problem thats' currently occurring post start-up.