### PR TITLE
Fix read preference tag selection bug

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -911,7 +911,7 @@ var clearCredentials = function(s, ns) {
 var filterByTags = function(readPreference, servers) {
   if(readPreference.tags == null) return servers;
   var filteredServers = [];
-  var tagsArray = !Array.isArray(readPreference.tags) ? [tags] : tags;
+  var tagsArray = !Array.isArray(readPreference.tags) ? [readPreference.tags] : readPreference.tags;
 
   // Iterate over the tags
   for(var j = 0; j < tagsArray.length; j++) {


### PR DESCRIPTION
Variable `tags` was not defined so it evaluated to `undefined` and when filtering for tags it always returned an empty array of servers. This caused an infinite retry loop of connecting to mongo.