### PR TITLE
Allow primary to be returned when secondaryPreferred is passed 

### DIFF
--- a/lib/topologies/replset_state.js
+++ b/lib/topologies/replset_state.js
@@ -541,11 +541,13 @@ ReplSetState.prototype.pickServer = function(readPreference) {
       // Pick nearest of any other servers available
       var server = pickNearest(this, readPreference);
       // No server in the window return primary
-      if(!server && readPreference.equals(ReadPreference.secondaryPreferred)) {
-        return this.primary;
-      } else {
+      if(server) {
         return server;
       }
+    }
+
+    if(readPreference.equals(ReadPreference.secondaryPreferred)){
+      return this.primary;
     }
 
     return null;


### PR DESCRIPTION
Allow primary to be returned when secondaryPreferred is passed and there are no secondaries. Fixes #116