### PR TITLE
Ensures calls to Pool.prototype.write() maintain their domain

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -822,7 +822,20 @@ Pool.prototype.write = function(buffer, options, cb) {
     if(cb) cb(new MongoError('pool destroyed'));
     return;
   }
-
+  
+  if (process.domain && typeof cb === "function") {
+    // if we have a domain bind to it
+    var oldCb = cb;
+    cb = process.domain.bind(function() {
+      // v8 - argumentsToArray one-liner
+      var args = new Array(arguments.length); for(var i = 0; i < arguments.length; i++) { args[i] = arguments[i]; }
+      // bounce off event loop so domain switch takes place
+      process.nextTick(function() {
+        oldCb.apply(null, args);
+      });
+    });
+  }
+  
   // Do we have an operation
   var operation = {
     buffer:buffer, cb: cb, raw: false, promoteLongs: true


### PR DESCRIPTION
Adds domain logic to the primary query entrance point. According to my tests this allowed the domain to remain for insert(), and find() with consistency, including calls routing through getMore() via batchSize() cursors. This is possible due to the pool refactor, previously it regarded domain peppering through the code base.