### PR TITLE
fix wrong opType passed to disconnectHandler.add

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -746,7 +746,7 @@ Mongos.prototype.update = function(ns, ops, options, callback) {
 
   // Not connected but we have a disconnecthandler
   if(!this.isConnected() && this.s.disconnectHandler != null) {
-    return this.s.disconnectHandler.add('insert', ns, ops, options, callback);
+    return this.s.disconnectHandler.add('update', ns, ops, options, callback);
   }
 
   // No mongos proxy available
@@ -775,7 +775,7 @@ Mongos.prototype.remove = function(ns, ops, options, callback) {
 
   // Not connected but we have a disconnecthandler
   if(!this.isConnected() && this.s.disconnectHandler != null) {
-    return this.s.disconnectHandler.add('insert', ns, ops, options, callback);
+    return this.s.disconnectHandler.add('remove', ns, ops, options, callback);
   }
 
   // No mongos proxy available

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -966,7 +966,7 @@ ReplSet.prototype.update = function(ns, ops, options, callback) {
 
   // Not connected but we have a disconnecthandler
   if(!this.s.replicaSetState.hasPrimary() && this.s.disconnectHandler != null) {
-    return this.s.disconnectHandler.add('insert', ns, ops, options, callback);
+    return this.s.disconnectHandler.add('update', ns, ops, options, callback);
   }
 
   // Execute write operation
@@ -990,7 +990,7 @@ ReplSet.prototype.remove = function(ns, ops, options, callback) {
 
   // Not connected but we have a disconnecthandler
   if(!this.s.replicaSetState.hasPrimary() && this.s.disconnectHandler != null) {
-    return this.s.disconnectHandler.add('insert', ns, ops, options, callback);
+    return this.s.disconnectHandler.add('remove', ns, ops, options, callback);
   }
 
   // Execute write operation


### PR DESCRIPTION
when ops jobs are stored using `disconnectHandler.add` wrong opType was 
specified:

- in /lib/topologies/replset.js: 
  'insert' was used instead 'update' and 'remove'
- in /lib/topologies/mongos.js:
  ’insert' was used instead of 'remove'


this lead to wrong operations being executed when connection was reestablished ( most of the time leading to operation error )