### PR TITLE
fix: don't reconnect multiple times in one connection

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -277,6 +277,8 @@ function attemptReconnect(self) {
     // If we have failure schedule a retry
     function _connectionFailureHandler(self, event) {
       return function() {
+        if (this._connectionFailHandled) return;
+        this._connectionFailHandled = true;
         // Destroy the connection
         this.destroy();
         // Count down the number of reconnects


### PR DESCRIPTION
when the network was cut off, the `close` event and `timeout` event will emitted both. https://github.com/christkv/mongodb-core/blob/2.0/lib/connection/pool.js#L318

this will leading to more and more reconnect attempts.