### PR TITLE
Allow setting promoteBuffers

### DIFF
--- a/lib/connection/commands.js
+++ b/lib/connection/commands.js
@@ -481,6 +481,9 @@ Response.prototype.parse = function(options) {
   var promoteValues = typeof options.promoteValues == 'boolean'
     ? options.promoteValues
     : this.opts.promoteValues;
+  var promoteBuffers = typeof options.promoteBuffers == 'boolean'
+    ? options.promoteBuffers
+    : this.opts.promoteBuffers
 
   //
   // Single document and documentsReturnedIn set
@@ -525,7 +528,7 @@ Response.prototype.parse = function(options) {
   for(var i = 0; i < this.numberReturned; i++) {
     var bsonSize = this.data[this.index] | this.data[this.index + 1] << 8 | this.data[this.index + 2] << 16 | this.data[this.index + 3] << 24;
     // Parse options
-    var _options = {promoteLongs: promoteLongs, promoteValues: promoteValues};
+    var _options = {promoteLongs: promoteLongs, promoteValues: promoteValues, promoteBuffers: promoteBuffers};
 
     // If we have raw results specified slice the return document
     if(raw) {

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -103,7 +103,8 @@ var Connection = function(messageHandler, options) {
   // Response options
   this.responseOptions = {
     promoteLongs: typeof options.promoteLongs == 'boolean' ?  options.promoteLongs : true,
-    promoteValues: typeof options.promoteValues == 'boolean' ? options.promoteValues : true
+    promoteValues: typeof options.promoteValues == 'boolean' ? options.promoteValues : true,
+    promoteBuffers: typeof options.promoteBuffers == 'boolean' ? options.promoteBuffers: false
   }
 
   // Flushing


### PR DESCRIPTION
Hi Christian,

Re: https://github.com/Automattic/mongoose/issues/4457, looks like the option added in https://github.com/mongodb/js-bson/pull/116 can't be set from mongodb-core or any higher level tools. Not sure how this relates to the `promoteValues` option you added in https://github.com/christkv/mongodb-core/commit/b1a482b9a2f068687cd490f08cd0853d493c9b84 but would be great to have some way to set `promoteBuffers` from mongoose