### PR TITLE
NODE-798 Driver hangs on count command in replica set with one member

### DIFF
--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -1083,7 +1083,7 @@ ReplSet.prototype.command = function(ns, cmd, options, callback) {
   // If the readPreference is primary and we have no primary, store it
   if(readPreference.preference == 'primary' && !this.s.replicaSetState.hasPrimary() && this.s.disconnectHandler != null) {
     return this.s.disconnectHandler.add('command', ns, cmd, options, callback);
-  } else if(readPreference.preference != 'primary' && !this.s.replicaSetState.hasSecondary() && this.s.disconnectHandler != null) {
+  } else if(readPreference.preference != 'primary' && !this.s.replicaSetState.hasSecondary() && !this.s.replicaSetState.hasPrimary() && this.s.disconnectHandler != null) {
     // Otherwise secondary is allowed
     return this.s.disconnectHandler.add('command', ns, cmd, options, callback);
   }

--- a/test/tests/functional/rs_mocks/operation_tests.js
+++ b/test/tests/functional/rs_mocks/operation_tests.js
@@ -103,3 +103,93 @@ exports['Correctly execute count command against replicaset with a single member
     }, 100)
   }
 }
+
+exports['Correctly execute count command against replicaset with a single member and secondaryPreferred'] = {
+  metadata: {
+    requires: {
+      generators: true,
+      topology: "single"
+    }
+  },
+
+  test: function(configuration, test) {
+    var ReplSet = configuration.require.ReplSet,
+      ObjectId = configuration.require.BSON.ObjectId,
+      ReadPreference = configuration.require.ReadPreference,
+      Connection = require('../../../../lib/connection/connection'),
+      Long = configuration.require.BSON.Long,
+      co = require('co'),
+      mockupdb = require('../../../mock');
+
+    // Contain mock server
+    var primaryServer = null;
+    var firstSecondaryServer = null;
+    var secondSecondaryServer = null;
+    var arbiterServer = null;
+    var running = true;
+    var currentIsMasterIndex = 0;
+
+    // Default message fields
+    var defaultFields = {
+      "setName": "rs", "setVersion": 1, "electionId": new ObjectId(),
+      "maxBsonObjectSize" : 16777216, "maxMessageSizeBytes" : 48000000,
+      "maxWriteBatchSize" : 1000, "localTime" : new Date(), "maxWireVersion" : 4,
+      "minWireVersion" : 0, "ok" : 1, "hosts": ["localhost:32000"]
+    }
+
+    // Primary server states
+    var primary = [extend(defaultFields, {
+      "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
+    })];
+
+    // Boot the mock
+    co(function*() {
+      primaryServer = yield mockupdb.createServer(32000, 'localhost');
+
+      // Primary state machine
+      co(function*() {
+        while(running) {
+          var request = yield primaryServer.receive();
+          var doc = request.document;
+          // console.log("======== doc")
+          // console.dir(doc)
+
+          if(doc.ismaster) {
+            request.reply(primary[currentIsMasterIndex]);
+          } else if(doc.count) {
+            request.reply({ok:1, n:1});
+          }
+        }
+      }).catch(function(err) {
+        console.log(err.stack);
+      });
+    });
+
+    Connection.enableConnectionAccounting();
+    // Attempt to connect
+    var server = new ReplSet([{ host: 'localhost', port: 32000 }], {
+        setName: 'rs',
+        connectionTimeout: 3000,
+        socketTimeout: 0,
+        haInterval: 2000,
+        size: 1,
+        disconnectHandler: {
+          add: function() {}, execute: function() {}
+        }
+    });
+
+    server.on('connect', function(server) {
+      server.command('test.test', {count: 'test'}, {readPreference: ReadPreference.secondaryPreferred}, function() {
+        primaryServer.destroy();
+        server.destroy();
+        running = false;
+        test.done();
+      });
+    });
+
+    // Gives proxies a chance to boot up
+    setTimeout(function() {
+      server.connect();
+    }, 100)
+  }
+}


### PR DESCRIPTION
`count` should not hangs on when replicat have only one primary but have `secondaryPreferred` preferred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/christkv/mongodb-core/141)
<!-- Reviewable:end -->
