### PR TITLE
fix typo in serverHeartbeatFailed event name

### DIFF
--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -559,7 +559,7 @@ function topologyMonitor(self, options) {
         // We had an error, remove it from the state
         if(err) {
           // Emit the server heartbeat failure
-          emitSDAMEvent(self, 'serverHearbeatFailed', { durationMS: latencyMS, failure: err, connectionId: _server.name });
+          emitSDAMEvent(self, 'serverHeartbeatFailed', { durationMS: latencyMS, failure: err, connectionId: _server.name });
         } else {
           // Update the server ismaster
           _server.ismaster = r.result;
@@ -1096,9 +1096,9 @@ Mongos.prototype.connections = function() {
  */
 
 /**
- * A topology serverHearbeatFailed SDAM event
+ * A topology serverHeartbeatFailed SDAM event
  *
- * @event Mongos#serverHearbeatFailed
+ * @event Mongos#serverHeartbeatFailed
  * @type {object}
  */
 

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -535,7 +535,7 @@ function topologyMonitor(self, options) {
         // We had an error, remove it from the state
         if(err) {
           // Emit the server heartbeat failure
-          emitSDAMEvent(self, 'serverHearbeatFailed', { durationMS: latencyMS, failure: err, connectionId: _server.name });
+          emitSDAMEvent(self, 'serverHeartbeatFailed', { durationMS: latencyMS, failure: err, connectionId: _server.name });
         } else {
           // Update the server ismaster
           _server.ismaster = r.result;
@@ -1358,9 +1358,9 @@ ReplSet.prototype.cursor = function(ns, cmd, cursorOptions) {
  */
 
 /**
- * A topology serverHearbeatFailed SDAM event
+ * A topology serverHeartbeatFailed SDAM event
  *
- * @event ReplSet#serverHearbeatFailed
+ * @event ReplSet#serverHeartbeatFailed
  * @type {object}
  */
 

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -166,7 +166,7 @@ var inquireServerState = function(self) {
         // Set server response time
         self.s.isMasterLatencyMS = latencyMS;
       } else {
-        emitSDAMEvent(self, 'serverHearbeatFailed', { durationMS: latencyMS, failure: err, connectionId: self.name });
+        emitSDAMEvent(self, 'serverHeartbeatFailed', { durationMS: latencyMS, failure: err, connectionId: self.name });
       }
 
       // Peforming an ismaster monitoring callback operation

--- a/test/tests/functional/sdam_monitoring_mocks/mongos_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/mongos_topology_tests.js
@@ -229,7 +229,7 @@ exports['SDAM Monitoring Should correctly connect to two proxies'] = {
       add({type: 'serverHeartbeatSucceeded', event: event});
     });
 
-    server.on('serverHearbeatFailed', function(event) {
+    server.on('serverHeartbeatFailed', function(event) {
       add({type: 'serverHeartbeatFailed', event: event});
     });
 
@@ -460,7 +460,7 @@ exports['SDAM Monitoring Should correctly failover due to proxy going away causi
       add({type: 'serverHeartbeatSucceeded', event: event});
     });
 
-    server.on('serverHearbeatFailed', function(event) {
+    server.on('serverHeartbeatFailed', function(event) {
       add({type: 'serverHeartbeatFailed', event: event});
     });
 
@@ -617,7 +617,7 @@ exports['SDAM Monitoring Should correctly bring back proxy and use it'] = {
       add({type: 'serverHeartbeatSucceeded', event: event});
     });
 
-    server.on('serverHearbeatFailed', function(event) {
+    server.on('serverHeartbeatFailed', function(event) {
       add({type: 'serverHeartbeatFailed', event: event});
     });
 

--- a/test/tests/functional/sdam_monitoring_mocks/replset_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/replset_topology_tests.js
@@ -194,9 +194,9 @@ exports['Successful emit SDAM monitoring events for replicaset'] = {
       // console.log(JSON.stringify(event, null, 2))
     });
 
-    server.on('serverHearbeatFailed', function(event) {
+    server.on('serverHeartbeatFailed', function(event) {
       add({type: 'serverHeartbeatFailed', event: event});
-      // console.log("----------------------------- serverHearbeatFailed")
+      // console.log("----------------------------- serverHeartbeatFailed")
       // console.log(JSON.stringify(event, null, 2))
     });
 


### PR DESCRIPTION
Fix a typo in the name of the serverHeartbeatFailed event