### PR TITLE
Fire callback when topology was destroyed

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -539,6 +539,10 @@ var nextFunction = function(self, callback) {
     // Topology is not connected, save the call in the provided store to be
     // Executed at some point when the handler deems it's reconnected
     if(!self.topology.isConnected(self.options) && self.disconnectHandler != null) {
+      if (self.topology.isDestroyed()) {
+        // Topology was destroyed, so don't try to wait for it to reconnect
+        return callback(new MongoError('Topology was destroyed'));
+      }
       return self.disconnectHandler.addObjectAndMethod('cursor', self, 'next', [callback], callback);
     }
 


### PR DESCRIPTION
Hi Christian,

Found an annoying issue where a cursor.next() will never fire its callback if the underlying topology ran out of `reconnectTries` or if `autoReconnect` is off. Came up when looking at https://github.com/Automattic/mongoose/issues/4581.