### PR TITLE
Fix undefined exception when no doc.

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -665,12 +665,12 @@ var nextFunction = function(self, callback) {
     var doc = self.cursorState.documents[self.cursorState.cursorIndex++];
 
     // Doc overflow
-    if(doc.$err) {
+    if(!doc || doc.$err) {
       // Ensure we kill the cursor on the server
       self.kill();
       // Set cursor in dead and notified state
       return setCursorDeadAndNotified(self, function() {
-        handleCallback(callback, new MongoError(doc.$err));
+        handleCallback(callback, new MongoError(doc ? doc.$err : undefined));
       });
     }
 


### PR DESCRIPTION
We are seeing a crash in mongodb-core when using a tailable cursor.

I have been unable to generate a test case that causes the problem but the exception occurs because doc is undefined so the access of .$err blows up.