### PR TITLE
emit error asynchronously when SSL connection throws

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -638,7 +638,9 @@ Pool.prototype.connect = function() {
     connection.connect();
   } catch(err) {
     // SSL or something threw on connect
-    self.emit('error', err);
+    process.nextTick(function() {
+      self.emit('error', err);
+    });
   }
 }
 


### PR DESCRIPTION
Re: Automattic/mongoose#4905

`tls.connect()` can throw a synchronous error, so it's best to ensure pool reports the error asynchronously so downstream callbacks don't get surprise same-tick callbacks