### PR TITLE
Defaults to 2000 only if connectionTimeout is not a number

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -216,7 +216,7 @@ function monitoringProcess(self) {
 
     // Execute the ismaster query
     self.s.pool.write(query, {
-      socketTimeout: self.s.options.connectionTimeout || 2000,
+      socketTimeout: (typeof self.s.options.connectionTimeout !== 'number') ? 2000 : self.s.options.connectionTimeout,
     }, function(err, result) {
       // Set initial lastIsMasterMS
       self.lastIsMasterMS = new Date().getTime() - start;


### PR DESCRIPTION
This allows to set connectionTimeout as 0 disabling the node.js idle timeout (https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback). The socket will then use the kernel default timeout (issue #161)