### PR TITLE
fix requiring bson-ext

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var BSON = require('bson');
+var require_optional = require('require_optional');
 
 try {
   // try { BSON = require('bson-ext'); } catch(err) {


### PR DESCRIPTION
This is causing the require of bson-ext to always fail and is causing issues with buffer deserialization in mongoose when bson-ext is used.