### PR TITLE
'family' was added to socket options to provide high priority for ipv6 addresses

### DIFF
--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -23,7 +23,7 @@ var connections = {};
  * @class
  * @param {string} options.host The server host
  * @param {number} options.port The server port
- * @param {number} options.family Version of IP stack. Defaults to 4.
+ * @param {number} [options.family=4] Version of IP stack. Defaults to 4.
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
  * @param {number} [options.keepAliveInitialDelay=0] Initial delay before TCP keep alive enabled
  * @param {boolean} [options.noDelay=true] TCP Connection no delay

--- a/lib/connection/connection.js
+++ b/lib/connection/connection.js
@@ -23,6 +23,7 @@ var connections = {};
  * @class
  * @param {string} options.host The server host
  * @param {number} options.port The server port
+ * @param {number} options.family Version of IP stack. Defaults to 4.
  * @param {boolean} [options.keepAlive=true] TCP Connection keep alive enabled
  * @param {number} [options.keepAliveInitialDelay=0] Initial delay before TCP keep alive enabled
  * @param {boolean} [options.noDelay=true] TCP Connection no delay
@@ -73,6 +74,7 @@ var Connection = function(messageHandler, options) {
   // Default options
   this.port = options.port || 27017;
   this.host = options.host || 'localhost';
+  this.family = typeof options.family == 'number' ? options.family : 4;
   this.keepAlive = typeof options.keepAlive == 'boolean' ? options.keepAlive : true;
   this.keepAliveInitialDelay = options.keepAliveInitialDelay || 0;
   this.noDelay = typeof options.noDelay == 'boolean' ? options.noDelay : true;
@@ -396,9 +398,10 @@ Connection.prototype.connect = function(_options) {
   }
 
   // Create new connection instance
-  self.connection = self.domainSocket
-    ? net.createConnection(self.host)
-    : net.createConnection(self.port, self.host);
+  var connection_options = self.domainSocket
+    ? {path: self.host}
+    : {port: self.port, host: self.host, family: self.family};
+  self.connection = net.createConnection(connection_options);
 
   // Set the options for the connection
   self.connection.setKeepAlive(self.keepAlive, self.keepAliveInitialDelay);


### PR DESCRIPTION
This option is needed when you have ipv4 interface and ipv4/v6 addresses at mongodb servervs, but only ipv6 connectivity to mongodb servers.