### PR TITLE
Use actual server type in standalone SDAM events:

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -287,7 +287,7 @@ var eventHandler = function(self, event) {
         if(!self.s.inTopology) {
           // Emit topology description changed if something listening
           sdam.emitTopologyDescriptionChanged(self, {
-            topologyType: 'Single', servers: [{address: self.name, arbiters: [], hosts: [], passives: [], type: 'Standalone'}]
+            topologyType: 'Single', servers: [{address: self.name, arbiters: [], hosts: [], passives: [], type: sdam.getTopologyType(self)}]
           });
         }
 


### PR DESCRIPTION
Currently the server type inside the topologyDescriptionChanged event
for a single topology is 'Standalone', which is unexpected. According to
the SDAM specification a TopologyDescription has a list of
ServerDescriptions, which had a type field indicating the type of server
it is and does not state that the server type never changes if the
topology is single.

My expectation is that a single connection to a replica set primary, for
example, would give me a topology type of 'Single' and a server type of
'RSPrimary', not 'Standalone' like it currently does.

The serverDescriptionChanged event properly has the type set.

I could not get the tests running locally - they just stop after the first step `[purge the directories]` - hence I have not added tests but the existing sdam server test should still pass.