### PR TITLE
refactor(assign): move assign to shared utils, replace extend

### DIFF
--- a/lib/connection/pool.js
+++ b/lib/connection/pool.js
@@ -8,7 +8,7 @@ var inherits = require('util').inherits,
   f = require('util').format,
   Query = require('./commands').Query,
   CommandResult = require('./command_result'),
-  assign = require('../topologies/shared').assign;
+  assign = require('../utils').assign;
 
 var MongoCR = require('../auth/mongocr')
   , X509 = require('../auth/x509')
@@ -618,7 +618,7 @@ Pool.prototype.connect = function() {
       moveConnectionBetween(connection, self.connectingConnections, self.availableConnections);
 
       // Emit the connect event
-      return self.emit('connect', self);      
+      return self.emit('connect', self);
     }
 
     // Apply any store credentials
@@ -868,7 +868,7 @@ Pool.prototype.destroy = function(force) {
       }
     }
 
-    // Destroy the topology 
+    // Destroy the topology
     return destroy(self, connections);
   }
 
@@ -905,7 +905,7 @@ Pool.prototype.destroy = function(force) {
 
       destroy(self, connections);
     // } else if (self.queue.length > 0 && !this.reconnectId) {
-      
+
     } else {
       // Ensure we empty the queue
       _execute(self)();

--- a/lib/topologies/mongos.js
+++ b/lib/topologies/mongos.js
@@ -8,7 +8,7 @@ var inherits = require('util').inherits,
   retrieveBSON = require('../connection/utils').retrieveBSON,
   MongoError = require('../error'),
   Server = require('./server'),
-  assign = require('./shared').assign,
+  assign = require('../utils').assign,
   clone = require('./shared').clone,
   sdam = require('./shared'),
   diff = require('./shared').diff,
@@ -268,7 +268,7 @@ function handleEvent(self) {
     self.emit('serverClosed', {
       topologyId: self.id,
       address: this.name
-    });     
+    });
   }
 }
 
@@ -393,7 +393,7 @@ function connectProxies(self, servers) {
       self.emit('serverOpening', {
         topologyId: self.id,
         address: server.name
-      });     
+      });
 
       // Emit the initial topology
       emitTopologyDescriptionChanged(self);
@@ -560,7 +560,7 @@ function reconnectProxies(self, proxies, callback) {
       self.emit('serverOpening', {
         topologyId: server.s.topologyId != -1 ? server.s.topologyId : self.id,
         address: server.name
-      });     
+      });
 
       // Add temp handlers
       server.once('connect', _handleEvent(self, 'connect'));
@@ -766,7 +766,7 @@ Mongos.prototype.destroy = function(options) {
     self.emit('serverClosed', {
       topologyId: self.id,
       address: x.name
-    });             
+    });
 
     // Destroy the server
     x.destroy(options);

--- a/lib/topologies/replset.js
+++ b/lib/topologies/replset.js
@@ -10,7 +10,7 @@ var inherits = require('util').inherits,
   MongoError = require('../error'),
   Server = require('./server'),
   ReplSetState = require('./replset_state'),
-  assign = require('./shared').assign,
+  assign = require('../utils').assign,
   clone = require('./shared').clone,
   Timeout = require('./shared').Timeout,
   Interval = require('./shared').Interval,
@@ -435,7 +435,7 @@ var pingServer = function(self, server, cb) {
 
 // Each server is monitored in parallel in their own timeout loop
 var monitorServer = function(host, self, options) {
-  // If this is not the initial scan  
+  // If this is not the initial scan
   // Is this server already being monitoried, then skip monitoring
   if(!options.haInterval) {
     for(var i = 0; i < self.intervalIds.length; i++) {
@@ -470,7 +470,7 @@ var monitorServer = function(host, self, options) {
         }
 
         // Filter out all called intervaliIds
-        self.intervalIds = self.intervalIds.filter(function(intervalId) { 
+        self.intervalIds = self.intervalIds.filter(function(intervalId) {
           return intervalId.isRunning();
         } );
 
@@ -550,7 +550,7 @@ function topologyMonitor(self, options) {
 
   if(_process === Timeout) {
     return connectNewServers(self, self.s.replicaSetState.unknownServers, function(err) {
-      // Don't emit errors if the connection was already 
+      // Don't emit errors if the connection was already
       if(self.state === DESTROYED || self.state === UNREFERENCED) {
         return;
       }
@@ -583,7 +583,7 @@ function topologyMonitor(self, options) {
       }
 
       connectNewServers(self, self.s.replicaSetState.unknownServers, function() {
-        var monitoringFrequencey = self.s.replicaSetState.hasPrimary() 
+        var monitoringFrequencey = self.s.replicaSetState.hasPrimary()
           ? _haInterval : self.s.minHeartbeatFrequencyMS;
 
         // Create a timeout

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -15,7 +15,7 @@ var inherits = require('util').inherits,
   ThreeTwoWireProtocolSupport = require('../wireprotocol/3_2_support'),
   BasicCursor = require('../cursor'),
   sdam = require('./shared'),
-  assign = require('./shared').assign,
+  assign = require('../utils').assign,
   createClientInfo = require('./shared').createClientInfo;
 
 // Used for filtering out fields for loggin

--- a/lib/topologies/shared.js
+++ b/lib/topologies/shared.js
@@ -180,31 +180,6 @@ var inquireServerState = function(self) {
   };
 }
 
-// Object.assign method or polyfille
-var assign = Object.assign ? Object.assign : function assign(target) {
-  if (target === undefined || target === null) {
-    throw new TypeError('Cannot convert first argument to object');
-  }
-
-  var to = Object(target);
-  for (var i = 1; i < arguments.length; i++) {
-    var nextSource = arguments[i];
-    if (nextSource === undefined || nextSource === null) {
-      continue;
-    }
-
-    var keysArray = Object.keys(Object(nextSource));
-    for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
-      var nextKey = keysArray[nextIndex];
-      var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
-      if (desc !== undefined && desc.enumerable) {
-        to[nextKey] = nextSource[nextKey];
-      }
-    }
-  }
-  return to;
-}
-
 //
 // Clone the options
 var cloneOptions = function(options) {
@@ -234,7 +209,7 @@ function Interval(fn, time) {
 
   this.isRunning = function () {
     return timer !== false;
-  };  
+  };
 }
 
 function Timeout(fn, time) {
@@ -256,7 +231,7 @@ function Timeout(fn, time) {
   this.isRunning = function () {
     if(timer && timer._called) return false;
     return timer !== false;
-  };  
+  };
 }
 
 function diff(previous, current) {
@@ -298,7 +273,7 @@ function diff(previous, current) {
 
     // Go over all the previous servers
     for(var i = 0; i < previous.servers.length; i++) {
-      if(previous.servers[i].address.toLowerCase() 
+      if(previous.servers[i].address.toLowerCase()
         === current.servers[j].address.toLowerCase()) {
         found = true;
         break;
@@ -346,7 +321,6 @@ module.exports.getTopologyType = getTopologyType;
 module.exports.emitServerDescriptionChanged = emitServerDescriptionChanged;
 module.exports.emitTopologyDescriptionChanged = emitTopologyDescriptionChanged;
 module.exports.cloneOptions = cloneOptions;
-module.exports.assign = assign;
 module.exports.createClientInfo = createClientInfo;
 module.exports.clone = clone;
 module.exports.diff = diff;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,32 @@
+/**
+ * Copy the values of all enumerable own properties from one or more
+ * source objects to a target object. It will return the target object.
+ */
+var assign = Object.assign ? Object.assign : function assign(target) {
+  if (target === undefined || target === null) {
+    throw new TypeError('Cannot convert first argument to object');
+  }
+
+  var to = Object(target);
+  for (var i = 1; i < arguments.length; i++) {
+    var nextSource = arguments[i];
+    if (nextSource === undefined || nextSource === null) {
+      continue;
+    }
+
+    var keysArray = Object.keys(Object(nextSource));
+    for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
+      var nextKey = keysArray[nextIndex];
+      var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
+      if (desc !== undefined && desc.enumerable) {
+        to[nextKey] = nextSource[nextKey];
+      }
+    }
+  }
+
+  return to;
+}
+
+module.exports = {
+  assign: assign
+};

--- a/test/tests/functional/mongos_mocks/mixed_seed_list_tests.js
+++ b/test/tests/functional/mongos_mocks/mixed_seed_list_tests.js
@@ -1,4 +1,5 @@
-"use strict"
+"use strict";
+var assign = require('../../../../lib/utils').assign;
 
 exports['Should correctly print warning when non mongos proxy passed in seed list'] = {
   metadata: {
@@ -25,12 +26,6 @@ exports['Should correctly print warning when non mongos proxy passed in seed lis
     var stopRespondingPrimary = false;
     var port = null;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -53,7 +48,7 @@ exports['Should correctly print warning when non mongos proxy passed in seed lis
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {}), extend(defaultRSFields, {})];
+    var serverIsMaster = [assign({}, defaultFields), assign({}, defaultRSFields)];
 
     // Boot the mock
     co(function*() {
@@ -152,12 +147,6 @@ exports['Should correctly print warning and error when no mongos proxies in seed
     var stopRespondingPrimary = false;
     var port = null;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultRSFields = {
       "setName": "rs", "setVersion": 1, "electionId": new ObjectId(),
@@ -167,7 +156,7 @@ exports['Should correctly print warning and error when no mongos proxies in seed
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultRSFields, {}), extend(defaultRSFields, {})];
+    var serverIsMaster = [assign({}, defaultRSFields), assign({}, defaultRSFields)];
 
     // Boot the mock
     co(function*() {
@@ -249,7 +238,7 @@ exports['Should correctly print warning and error when no mongos proxies in seed
       });
 
       setTimeout(function() { server.connect(); }, 100);
-    }).catch(function(err) {        
+    }).catch(function(err) {
     });
   }
 }

--- a/test/tests/functional/mongos_mocks/multiple_proxies_tests.js
+++ b/test/tests/functional/mongos_mocks/multiple_proxies_tests.js
@@ -1,4 +1,5 @@
-"use strict"
+"use strict";
+var assign = require('../../../../lib/utils').assign;
 
 var timeoutPromise = function(timeout) {
   return new Promise(function(resolve, reject) {
@@ -32,12 +33,6 @@ exports['Should correctly load-balance the operations'] = {
     var stopRespondingPrimary = false;
     var port = null;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -52,7 +47,7 @@ exports['Should correctly load-balance the operations'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(11000, 'localhost');
@@ -93,7 +88,6 @@ exports['Should correctly load-balance the operations'] = {
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
 
       // Attempt to connect
@@ -172,12 +166,6 @@ exports['Should ignore one of the mongos instances due to being outside the late
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -192,7 +180,7 @@ exports['Should ignore one of the mongos instances due to being outside the late
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(11002, 'localhost');

--- a/test/tests/functional/mongos_mocks/proxy_failover_tests.js
+++ b/test/tests/functional/mongos_mocks/proxy_failover_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 var timeoutPromise = function(timeout) {
   return new Promise(function(resolve, reject) {
     setTimeout(function() {
@@ -29,12 +32,6 @@ exports['Should correctly failover due to proxy going away causing timeout'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -49,7 +46,7 @@ exports['Should correctly failover due to proxy going away causing timeout'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(52007, 'localhost');
@@ -91,7 +88,6 @@ exports['Should correctly failover due to proxy going away causing timeout'] = {
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     }).catch(function(err) {
     });
@@ -154,12 +150,6 @@ exports['Should correctly bring back proxy and use it'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -174,7 +164,7 @@ exports['Should correctly bring back proxy and use it'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(52009, 'localhost');
@@ -218,7 +208,6 @@ exports['Should correctly bring back proxy and use it'] = {
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     }).catch(function(err) {
     });
@@ -308,12 +297,6 @@ exports['Should correctly bring back both proxies and use it'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -328,7 +311,7 @@ exports['Should correctly bring back both proxies and use it'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(52011, 'localhost');
@@ -375,7 +358,6 @@ exports['Should correctly bring back both proxies and use it'] = {
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 1000);
     }).catch(function(err) {
     });

--- a/test/tests/functional/mongos_mocks/proxy_read_preference_tests.js
+++ b/test/tests/functional/mongos_mocks/proxy_read_preference_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 exports['Should correctly set query and readpreference field on wire protocol for 3.2'] = {
   metadata: {
     requires: {
@@ -23,12 +26,6 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -43,7 +40,7 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Received command on server
     var command = null;
     // Boot the mock
@@ -79,7 +76,6 @@ exports['Should correctly set query and readpreference field on wire protocol fo
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     }).catch(function(err) {
     });
@@ -153,12 +149,6 @@ exports['Should correctly set query and near readpreference field on wire protoc
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -173,7 +163,7 @@ exports['Should correctly set query and near readpreference field on wire protoc
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Received command on server
     var command = null;
     // Boot the mock
@@ -209,7 +199,6 @@ exports['Should correctly set query and near readpreference field on wire protoc
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     }).catch(function(err) {
     });
@@ -280,12 +269,6 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     var mongos2 = null;
     var running = true;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -300,7 +283,7 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Received command on server
     var command = null;
     // Boot the mock
@@ -401,12 +384,6 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -419,7 +396,7 @@ exports['Should correctly set query and readpreference field on wire protocol fo
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     // Received command on server
     var command = null;
     // Boot the mock
@@ -447,7 +424,6 @@ exports['Should correctly set query and readpreference field on wire protocol fo
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     }).catch(function(err) {
     });

--- a/test/tests/functional/mongos_mocks/single_proxy_connection_tests.js
+++ b/test/tests/functional/mongos_mocks/single_proxy_connection_tests.js
@@ -1,4 +1,6 @@
+"use strict";
 var f = require('util').format;
+var assign = require('../../../../lib/utils').assign;
 
 exports['Should correctly timeout mongos socket operation and then correctly re-execute'] = {
   metadata: {
@@ -23,12 +25,6 @@ exports['Should correctly timeout mongos socket operation and then correctly re-
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -43,7 +39,7 @@ exports['Should correctly timeout mongos socket operation and then correctly re-
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
@@ -88,7 +84,6 @@ exports['Should correctly timeout mongos socket operation and then correctly re-
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 500);
     }).catch(function(err) {
     });
@@ -159,12 +154,6 @@ exports['Should not fail due to available connections equal to 0 during ha proce
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -179,7 +168,7 @@ exports['Should not fail due to available connections equal to 0 during ha proce
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [ assign({}, defaultFields) ];
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {

--- a/test/tests/functional/rs_mocks/add_remove_tests.js
+++ b/test/tests/functional/rs_mocks/add_remove_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Successfully add a new secondary server to the set'] = {
   metadata: {
@@ -48,31 +35,31 @@ exports['Successfully add a new secondary server to the set'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }),extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000",
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
@@ -240,23 +227,23 @@ exports['Successfully remove a secondary server from the set'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     }), { "ismaster" : true,
       "maxBsonObjectSize" : 16777216, "maxMessageSizeBytes" : 48000000,
@@ -265,9 +252,9 @@ exports['Successfully remove a secondary server from the set'] = {
     }];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }),extend(defaultFields, {
+    }),assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000",
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
     })];
@@ -462,43 +449,43 @@ exports['Successfully remove and re-add secondary server to the set'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     }), { "ismaster" : true,
       "maxBsonObjectSize" : 16777216, "maxMessageSizeBytes" : 48000000,
       "maxWriteBatchSize" : 1000, "localTime" : new Date(), "maxWireVersion" : 3,
       "minWireVersion" : 0, "ok" : 1
-    }, extend(defaultFields, {
+    }, assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }),extend(defaultFields, {
+    }),assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000",
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002"], "setVersion": 2
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -698,31 +685,31 @@ exports['Successfully add a new secondary server to the set and ensure ha Monito
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" },
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }),extend(defaultFields, {
+    }),assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000",
       "hosts": ["localhost:32000", "localhost:32001", "localhost:32002", "localhost:32003"], "setVersion": 2
     })];

--- a/test/tests/functional/rs_mocks/all_servers_close_tests.js
+++ b/test/tests/functional/rs_mocks/all_servers_close_tests.js
@@ -1,22 +1,8 @@
 "use strict"
-
 var f = require('util').format;
+var assign = require('../../../../lib/utils').assign;
 
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
-
-exports['Successful reconnect when driver looses touch with entire replicaset'] = {
+exports['Successful reconnect when driver loses touch with entire replicaset'] = {
   metadata: {
     requires: {
       generators: true,
@@ -51,17 +37,17 @@ exports['Successful reconnect when driver looses touch with entire replicaset'] 
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -272,17 +258,17 @@ exports['Successfully come back from a dead replicaset that has been unavailable
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:34000", "primary": "localhost:34000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:34001", "primary": "localhost:34000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:34002", "primary": "localhost:34000"
     })];
 

--- a/test/tests/functional/rs_mocks/connection_tests.js
+++ b/test/tests/functional/rs_mocks/connection_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arbiter'] = {
   metadata: {
@@ -47,17 +34,17 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -200,17 +187,17 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -352,12 +339,12 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary but missi
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
@@ -483,7 +470,7 @@ exports['Fail to connect due to missing primary'] = {
     }
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
@@ -576,12 +563,12 @@ exports['Successful connection to replicaset of 0 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -701,17 +688,17 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -855,17 +842,17 @@ exports['Should print socketTimeout warning due to socketTimeout < haInterval'] 
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -985,12 +972,12 @@ exports['Should connect with a replicaset with a single primary and secondary'] 
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
@@ -1108,17 +1095,17 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -1261,17 +1248,17 @@ exports['Successful connection to replicaset of 1 primary, 0 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -1399,17 +1386,17 @@ exports['Successful connection to replicaset of 1 primary, 1 secondary and 1 arb
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
@@ -1536,12 +1523,12 @@ exports['Correctly return lastIsMaster when connected to a secondary only for a 
     }
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 

--- a/test/tests/functional/rs_mocks/failover_tests.js
+++ b/test/tests/functional/rs_mocks/failover_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Successfully failover to new primary'] = {
   metadata: {
@@ -51,31 +38,31 @@ exports['Successfully failover to new primary'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];
@@ -283,31 +270,31 @@ exports['Successfully failover to new primary and emit reconnect event'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32001", "tags" : { "loc" : "ny" },
       "electionId": electionIds[1]
     })];

--- a/test/tests/functional/rs_mocks/maintanance_mode_tests.js
+++ b/test/tests/functional/rs_mocks/maintanance_mode_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Successfully detect server in maintanance mode'] = {
   metadata: {
@@ -48,30 +35,30 @@ exports['Successfully detect server in maintanance mode'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     }), { "ismaster" : true,
       "ismaster":false, "secondary":false, "arbiterOnly": false, "me": "localhost:32003", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     }];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }),extend(defaultFields, {
+    }),assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 

--- a/test/tests/functional/rs_mocks/monitoring_tests.js
+++ b/test/tests/functional/rs_mocks/monitoring_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 var timeoutPromise = function(timeout) {
   return new Promise(function(resolve, reject) {
     setTimeout(function() {
@@ -32,12 +35,6 @@ exports['Should correctly connect to a replicaset where the primary hangs causin
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[currentIsMasterState],
@@ -47,23 +44,23 @@ exports['Should correctly connect to a replicaset where the primary hangs causin
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001"
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001"
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32001"
     })];
 
@@ -244,12 +241,6 @@ exports['Should correctly prune intervalIds array'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[currentIsMasterState],
@@ -259,23 +250,23 @@ exports['Should correctly prune intervalIds array'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001"
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001"
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32001"
     })];
 

--- a/test/tests/functional/rs_mocks/no_primary_found_tests.js
+++ b/test/tests/functional/rs_mocks/no_primary_found_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 exports['Should correctly connect to a replicaset where the arbiter hangs no primary found error'] = {
   metadata: {
     requires: {
@@ -20,12 +23,6 @@ exports['Should correctly connect to a replicaset where the arbiter hangs no pri
     var arbiterServer = null;
     var running = true;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": new ObjectId(),
@@ -36,22 +33,22 @@ exports['Should correctly connect to a replicaset where the arbiter hangs no pri
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000"
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32003", "primary": "localhost:32000"
     })];
 

--- a/test/tests/functional/rs_mocks/operation_tests.js
+++ b/test/tests/functional/rs_mocks/operation_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Correctly execute count command against replicaset with a single member'] = {
   metadata: {
@@ -48,7 +35,7 @@ exports['Correctly execute count command against replicaset with a single member
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
@@ -138,7 +125,7 @@ exports['Correctly execute count command against replicaset with a single member
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 

--- a/test/tests/functional/rs_mocks/primary_loses_network_tests.js
+++ b/test/tests/functional/rs_mocks/primary_loses_network_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Recover from Primary loosing network connectivity'] = {
   metadata: {
@@ -49,23 +36,23 @@ exports['Recover from Primary loosing network connectivity'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" },
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32002", "tags" : { "loc" : "sf" },
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32002", "primary": "localhost:32002", "tags" : { "loc" : "sf" }
     })];
 

--- a/test/tests/functional/rs_mocks/read_preferences_tests.js
+++ b/test/tests/functional/rs_mocks/read_preferences_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 exports['Should correctly connect to a replicaset and select the correct tagged secondary server'] = {
   metadata: {
     requires: {
@@ -24,12 +27,6 @@ exports['Should correctly connect to a replicaset and select the correct tagged 
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -39,17 +36,17 @@ exports['Should correctly connect to a replicaset and select the correct tagged 
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -202,12 +199,6 @@ exports['Should correctly connect to a replicaset and select the primary server'
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -217,17 +208,17 @@ exports['Should correctly connect to a replicaset and select the primary server'
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -363,12 +354,6 @@ exports['Should correctly round robin secondary reads'] = {
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -378,17 +363,17 @@ exports['Should correctly round robin secondary reads'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -547,12 +532,6 @@ exports['Should correctly fall back to a secondary server if the readPreference 
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -562,12 +541,12 @@ exports['Should correctly fall back to a secondary server if the readPreference 
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000"
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000"
     })];
 
@@ -607,7 +586,7 @@ exports['Should correctly fall back to a secondary server if the readPreference 
       });
 
       // mock ops store from node-mongodb-native for handling repl set disconnects
-      mockDisconnectHandler = {
+      var mockDisconnectHandler = {
         add: function(opType, ns, ops, options, callback) {
           // Command issued to replSet will fail immediately if !server.isConnected()
           return callback(MongoError.create({message: "no connection available", driver:true}));
@@ -716,12 +695,6 @@ exports['Should correctly fallback to secondaries when primary not available'] =
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -731,17 +704,17 @@ exports['Should correctly fallback to secondaries when primary not available'] =
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -898,12 +871,6 @@ exports['Should correctly connect to a replicaset and perform correct nearness r
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -913,17 +880,17 @@ exports['Should correctly connect to a replicaset and perform correct nearness r
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -1083,12 +1050,6 @@ exports['Should correctly connect to a replicaset and perform correct nearness r
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -1098,17 +1059,17 @@ exports['Should correctly connect to a replicaset and perform correct nearness r
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -1265,12 +1226,6 @@ exports['Should correctly connect connect to single server replicaset and peform
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -1280,7 +1235,7 @@ exports['Should correctly connect connect to single server replicaset and peform
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
@@ -1378,12 +1333,6 @@ exports['Should only read from secondaries when read preference secondaryPreferr
     var running = true;
     var electionIds = [new ObjectId(), new ObjectId()];
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "setName": "rs", "setVersion": 1, "electionId": electionIds[0],
@@ -1393,17 +1342,17 @@ exports['Should only read from secondaries when read preference secondaryPreferr
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var secondSecondary = [extend(defaultFields, {
+    var secondSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32002", "primary": "localhost:32000", "tags" : { "loc" : "dc" }
     })];
 
@@ -1503,7 +1452,7 @@ exports['Should only read from secondaries when read preference secondaryPreferr
                 firstSecondaryServer.destroy();
                 secondSecondaryServer.destroy();
                 server.destroy();
-                running = false; 
+                running = false;
 
                 setTimeout(function() {
                   test.done();

--- a/test/tests/functional/rs_mocks/step_down_tests.js
+++ b/test/tests/functional/rs_mocks/step_down_tests.js
@@ -1,4 +1,5 @@
 "use strict";
+var assign = require('../../../../lib/utils').assign;
 
 // SCENARIO
 // ------------------------------------------------------------------
@@ -6,20 +7,6 @@
 // 2. Continuously streaming Query using find
 // 3. Step down primary and re-elect new primary before query finishes.
 // 4. No disconnected servers detected (new primary never detected).
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
 
 // exports['Successfully finish query executing against secondary during primary stepDown'] = {
 //   metadata: {
@@ -65,25 +52,25 @@ var extend = function(template, fields) {
 //     }
 
 //     // Primary server states
-//     var primary = [extend(defaultFields, {
+//     var primary = [assign({}, defaultFields, {
 //       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-//     }), extend(defaultFields, {
+//     }), assign({}, defaultFields, {
 //       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-//     }), extend(defaultFields, {
+//     }), assign({}, defaultFields, {
 //       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
 //     })];
 
 //     // Primary server states
-//     var firstSecondary = [extend(defaultFields, {
+//     var firstSecondary = [assign({}, defaultFields, {
 //       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-//     }), extend(defaultFields, {
+//     }), assign({}, defaultFields, {
 //       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-//     }), extend(defaultFields, {
+//     }), assign({}, defaultFields, {
 //       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
 //     })];
 
 //     // Primary server states
-//     var arbiter = [extend(defaultFields, {
+//     var arbiter = [assign({}, defaultFields, {
 //       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
 //     })];
 

--- a/test/tests/functional/sdam_monitoring_mocks/mongos_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/mongos_topology_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 var timeoutPromise = function(timeout) {
   return new Promise(function(resolve, reject) {
     setTimeout(function() {
@@ -27,12 +30,6 @@ exports['SDAM Monitoring Should correctly connect to two proxies'] = {
     // Current index for the ismaster
     var currentStep = 0;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -47,7 +44,7 @@ exports['SDAM Monitoring Should correctly connect to two proxies'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(62000, 'localhost');
@@ -261,12 +258,6 @@ exports['SDAM Monitoring Should correctly failover due to proxy going away causi
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -281,7 +272,7 @@ exports['SDAM Monitoring Should correctly failover due to proxy going away causi
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(62002, 'localhost');
@@ -321,7 +312,6 @@ exports['SDAM Monitoring Should correctly failover due to proxy going away causi
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     });
 
@@ -492,12 +482,6 @@ exports['SDAM Monitoring Should correctly bring back proxy and use it'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -512,7 +496,7 @@ exports['SDAM Monitoring Should correctly bring back proxy and use it'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     // Boot the mock
     co(function*() {
       mongos1 = yield mockupdb.createServer(62004, 'localhost');

--- a/test/tests/functional/sdam_monitoring_mocks/replset_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/replset_topology_tests.js
@@ -1,18 +1,5 @@
 "use strict";
-
-// Extend the object
-var extend = function(template, fields) {
-  var object = {};
-  for(var name in template) {
-    object[name] = template[name];
-  }
-
-  for(var name in fields) {
-   object[name] = fields[name];
-  }
-
-  return object;
-}
+var assign = require('../../../../lib/utils').assign;
 
 exports['Successful emit SDAM monitoring events for replicaset'] = {
   metadata: {
@@ -46,29 +33,29 @@ exports['Successful emit SDAM monitoring events for replicaset'] = {
     }
 
     // Primary server states
-    var primary = [extend(defaultFields, {
+    var primary = [assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32000", "tags" : { "loc" : "ny" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32000", "primary": "localhost:32001", "tags" : { "loc" : "ny" }
     })];
 
     // Primary server states
-    var firstSecondary = [extend(defaultFields, {
+    var firstSecondary = [assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":true, "me": "localhost:32001", "primary": "localhost:32000", "tags" : { "loc" : "sf" }
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":true, "secondary":false, "me": "localhost:32001", "primary": "localhost:32001", "tags" : { "loc" : "sf" }
     })];
 
     // Primary server states
-    var arbiter = [extend(defaultFields, {
+    var arbiter = [assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32000"
-    }), extend(defaultFields, {
+    }), assign({}, defaultFields, {
       "ismaster":false, "secondary":false, "arbiterOnly": true, "me": "localhost:32002", "primary": "localhost:32001"
     })];
 
@@ -286,7 +273,7 @@ exports['Successful emit SDAM monitoring events for replicaset'] = {
             "to": "RSPrimary"
           }
         ]
-      }      
+      }
     };
 
     var document2 = {

--- a/test/tests/functional/sdam_monitoring_mocks/single_topology_tests.js
+++ b/test/tests/functional/sdam_monitoring_mocks/single_topology_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 exports['Should correctly emit sdam monitoring events for single server'] = {
   metadata: {
     requires: {
@@ -20,12 +23,6 @@ exports['Should correctly emit sdam monitoring events for single server'] = {
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -39,7 +36,7 @@ exports['Should correctly emit sdam monitoring events for single server'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
@@ -49,6 +46,7 @@ exports['Should correctly emit sdam monitoring events for single server'] = {
     }
 
     // Boot the mock
+    var __server;
     co(function*() {
       __server = yield mockupdb.createServer(37018, 'localhost');
 
@@ -193,12 +191,6 @@ exports['Should correctly emit sdam monitoring events for single server, with co
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -213,7 +205,7 @@ exports['Should correctly emit sdam monitoring events for single server, with co
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
@@ -223,6 +215,7 @@ exports['Should correctly emit sdam monitoring events for single server, with co
     }
 
     // Boot the mock
+    var __server;
     co(function*() {
       __server = yield mockupdb.createServer(37008, 'localhost');
 

--- a/test/tests/functional/single_mocks/timeout_tests.js
+++ b/test/tests/functional/single_mocks/timeout_tests.js
@@ -1,3 +1,6 @@
+"use strict";
+var assign = require('../../../../lib/utils').assign;
+
 exports['Should correctly timeout socket operation and then correctly re-execute'] = {
   metadata: {
     requires: {
@@ -20,12 +23,6 @@ exports['Should correctly timeout socket operation and then correctly re-execute
     // Primary stop responding
     var stopRespondingPrimary = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -39,7 +36,7 @@ exports['Should correctly timeout socket operation and then correctly re-execute
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
@@ -81,7 +78,6 @@ exports['Should correctly timeout socket operation and then correctly re-execute
       // Start dropping the packets
       setTimeout(function() {
         stopRespondingPrimary = true;
-        currentIsMasterState = 1;
       }, 5000);
     });
 
@@ -153,12 +149,6 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
     // Should fail due to broken pipe
     var brokenPipe = false;
 
-    // Extend the object
-    var extend = function(template, fields) {
-      for(var name in template) fields[name] = template[name];
-      return fields;
-    }
-
     // Default message fields
     var defaultFields = {
       "ismaster" : true,
@@ -172,7 +162,8 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
     }
 
     // Primary server states
-    var serverIsMaster = [extend(defaultFields, {})];
+    var serverIsMaster = [assign({}, defaultFields)];
+
     var timeoutPromise = function(timeout) {
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
@@ -182,6 +173,7 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
     }
 
     // Boot the mock
+    var __server;
     co(function*() {
       __server = yield mockupdb.createServer(37017, 'localhost', {
         onRead: function(server, connection, buffer, bytesRead) {
@@ -278,8 +270,6 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
     // console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 1")
 
     server.once('reconnect', function(_server) {
-      // console.log("!!!! server reconnect")
-      // console.dir(_server)
       _server.insert('test.test', [{created:new Date()}], function(err, r) {
         test.ok(brokenPipe);
         _server.destroy();
@@ -290,7 +280,6 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
     });
 
     server.on('error', function(){});
-    // console.log("!!! connect")
     setTimeout(function() { server.connect(); }, 100);
   }
 }
@@ -317,12 +306,6 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
 //     // Primary stop responding
 //     var stopRespondingPrimary = false;
 //
-//     // Extend the object
-//     var extend = function(template, fields) {
-//       for(var name in template) fields[name] = template[name];
-//       return fields;
-//     }
-//
 //     // Default message fields
 //     var defaultFields = {
 //       "ismaster" : true,
@@ -336,7 +319,7 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
 //     }
 //
 //     // Primary server states
-//     var serverIsMaster = [extend(defaultFields, {})];
+//     var serverIsMaster = [assign({}, defaultFields)];
 //     var timeoutPromise = function(timeout) {
 //       return new Promise(function(resolve, reject) {
 //         setTimeout(function() {
@@ -373,7 +356,6 @@ exports['Should correctly recover from an immediate shutdown mid insert'] = {
 //       // // Start dropping the packets
 //       // setTimeout(function() {
 //       //   stopRespondingPrimary = true;
-//       //   currentIsMasterState = 1;
 //       // }, 5000);
 //     });
 //


### PR DESCRIPTION
We already include a polyfill for `Object.assign` in the shared
topology utils, so this change moves that to a more centralized
location and replaces all inline implementations of a similar
`extend` method.