### PR TITLE
Emit SDAM events on close and reconnect:

### DIFF
--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -312,6 +312,13 @@ var eventHandler = function(self, event) {
         delete servers[self.id];
       }
 
+      if (event === 'close') {
+        // Reconnecting emits a server description changed event going to unknown.
+        sdam.emitServerDescriptionChanged(self, {
+          address: self.name, arbiters: [], hosts: [], passives: [], type: 'Unknown'
+        });
+      }
+
       // Reconnect failed return error
       if(event == 'reconnectFailed') {
         self.emit('reconnectFailed', err);
@@ -331,6 +338,11 @@ var eventHandler = function(self, event) {
 
       // Reconnect event, emit the server
       if(event == 'reconnect') {
+        // Reconnecting emits a server description changed event going from unknown to the
+        // current server type.
+        sdam.emitServerDescriptionChanged(self, {
+          address: self.name, arbiters: [], hosts: [], passives: [], type: sdam.getTopologyType(self)
+        });
         return self.emit(event, self);
       }
 

--- a/lib/topologies/server.js
+++ b/lib/topologies/server.js
@@ -313,7 +313,7 @@ var eventHandler = function(self, event) {
       }
 
       if (event === 'close') {
-        // Reconnecting emits a server description changed event going to unknown.
+        // Closing emits a server description changed event going to unknown.
         sdam.emitServerDescriptionChanged(self, {
           address: self.name, arbiters: [], hosts: [], passives: [], type: 'Unknown'
         });


### PR DESCRIPTION
According to the SDAM specification, when a server isMaster fails either
due to a network issue, the server is not available, or ok !== 1 then
the server type must change to Unknown. This must then emit a
serverDescriptionChanged event since the type has changed.

This pull emits that event now when the server is closed to set it as
Unknown, and when the server reconnects to set it back to the proper
type. This was previously happening on single server types.

https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#type

Also I noticed a lot of tests seem to be generating `(node:46897) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 20): Error: mock server is in destroyed state` and the tests passing seem to have a lot of false positives. When I enable console logging in the SDAM tests on the `serverDescriptionChanged` in the single_topology_tests.js, I only see it getting fired once, even though there are expectations in 2 tests of it getting fired. I would have expected the tests to actually be failing.