### PR TITLE
NODE-1080: export MongoError and MongoNetworkError at top-level

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ try {
 } catch(err) {}
 
 module.exports = {
-    MongoError: require('./lib/error')
+    MongoError: require('./lib/error').MongoError
+  , MongoNetworkError: require('./lib/error').MongoNetworkError
   , Connection: require('./lib/connection/connection')
   , Server: require('./lib/topologies/server')
   , ReplSet: require('./lib/topologies/replset')


### PR DESCRIPTION
Previously `MongoError` and `MongoNetworkError` were contained inside `MongoError`. This PR moves them to be top-level exports of mongodb-core.