### PR TITLE
require saslprep only if it is needed

### DIFF
--- a/lib/auth/scram.js
+++ b/lib/auth/scram.js
@@ -15,11 +15,15 @@ function saslprep(password) {
     } catch (e) {
       // don't do anything;
       console.warn('Warning: no saslprep library specified. Passwords will not be sanitized');
-      return password;
+      _saslprep = identity;
     }
   }
 
   return _saslprep(password);
+}
+
+function identity(password) {
+  return password;
 }
 
 var BSON = retrieveBSON(),


### PR DESCRIPTION
Requiring saslprep adds 1s to start an application using MongoDB.
It is especially painful in tests, as certain frameworks spins out
multiple processes (ava, tap). This PR delays the load of `saslprep` until the last possible minute.  

Before: [![85553 clinic-flame](https://user-images.githubusercontent.com/52195/45285344-3f74df80-b4e3-11e8-961b-ff22c32f801e.png)
](https://upload.clinicjs.org/public/01b0a0e85b6b32b273a4b68c27819643fe5d6c19a4946f53cb31a9b194725c12/85553.clinic-flame.html)

After: [![88540 clinic-flame](https://user-images.githubusercontent.com/52195/45285360-4b60a180-b4e3-11e8-93c8-6ff3072df7e2.png)
](https://upload.clinicjs.org/public/1642e0eb4fb2f11a39db3bd9ef7ce7a3c1be4272c4ddc53134c0ad2d85cc8c67/88540.clinic-flame.html)

(Taken with [node-clinic](https://clinicjs.org/))


