### PR TITLE
chore: allow using bson v1.x with v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "core"
   ],
   "dependencies": {
-    "bson": "~1.0.4",
+    "bson": "1.x",
     "require_optional": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Re: https://github.com/Automattic/mongoose/issues/10484 . I know this branch is long out of date, but may be helpful to allow people that are having trouble upgrading to avoid the security warnings in bson 1.0.x.